### PR TITLE
feat: implement inspection and approval modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.withType(Test) {

--- a/src/main/java/com/cmms11/approval/Approval.java
+++ b/src/main/java/com/cmms11/approval/Approval.java
@@ -1,0 +1,60 @@
+package com.cmms11.approval;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: Approval
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 헤더 엔티티.
+ */
+@Entity
+@Table(name = "approval")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Approval {
+
+    @EmbeddedId
+    private ApprovalId id;
+
+    @Column(length = 100)
+    private String title;
+
+    @Column(length = 10)
+    private String status;
+
+    @Column(name = "ref_entity", length = 64)
+    private String refEntity;
+
+    @Column(name = "ref_id", length = 10)
+    private String refId;
+
+    @Lob
+    @Column
+    private String content;
+
+    @Column(name = "file_group_id", length = 100)
+    private String fileGroupId;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", length = 10)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 10)
+    private String updatedBy;
+}

--- a/src/main/java/com/cmms11/approval/ApprovalId.java
+++ b/src/main/java/com/cmms11/approval/ApprovalId.java
@@ -1,0 +1,32 @@
+package com.cmms11.approval;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: ApprovalId
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 헤더 복합키.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ApprovalId implements Serializable {
+
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "approval_id", length = 10, nullable = false)
+    private String approvalId;
+}

--- a/src/main/java/com/cmms11/approval/ApprovalRepository.java
+++ b/src/main/java/com/cmms11/approval/ApprovalRepository.java
@@ -1,0 +1,32 @@
+package com.cmms11.approval;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: ApprovalRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 헤더에 대한 CRUD 및 검색 레포지토리.
+ */
+public interface ApprovalRepository extends JpaRepository<Approval, ApprovalId> {
+
+    Page<Approval> findByIdCompanyId(String companyId, Pageable pageable);
+
+    @Query(
+        "select a from Approval a " +
+        "where a.id.companyId = :companyId and (a.id.approvalId like :keyword or a.title like :keyword)"
+    )
+    Page<Approval> search(
+        @Param("companyId") String companyId,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<Approval> findByIdCompanyIdAndIdApprovalId(String companyId, String approvalId);
+}

--- a/src/main/java/com/cmms11/approval/ApprovalRequest.java
+++ b/src/main/java/com/cmms11/approval/ApprovalRequest.java
@@ -1,0 +1,25 @@
+package com.cmms11.approval;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * 이름: ApprovalRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 생성/수정 요청 DTO.
+ */
+public record ApprovalRequest(
+    @Size(max = 10) String approvalId,
+    @NotBlank @Size(max = 100) String title,
+    @Size(max = 10) String status,
+    @Size(max = 64) String refEntity,
+    @Size(max = 10) String refId,
+    String content,
+    @Size(max = 100) String fileGroupId,
+    @Valid List<ApprovalStepRequest> steps
+) {
+}

--- a/src/main/java/com/cmms11/approval/ApprovalResponse.java
+++ b/src/main/java/com/cmms11/approval/ApprovalResponse.java
@@ -1,0 +1,44 @@
+package com.cmms11.approval;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 이름: ApprovalResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 응답 DTO.
+ */
+public record ApprovalResponse(
+    String approvalId,
+    String title,
+    String status,
+    String refEntity,
+    String refId,
+    String content,
+    String fileGroupId,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy,
+    List<ApprovalStepResponse> steps
+) {
+    public static ApprovalResponse from(Approval approval, List<ApprovalStepResponse> steps) {
+        String approvalId = approval.getId() != null ? approval.getId().getApprovalId() : null;
+        return new ApprovalResponse(
+            approvalId,
+            approval.getTitle(),
+            approval.getStatus(),
+            approval.getRefEntity(),
+            approval.getRefId(),
+            approval.getContent(),
+            approval.getFileGroupId(),
+            approval.getCreatedAt(),
+            approval.getCreatedBy(),
+            approval.getUpdatedAt(),
+            approval.getUpdatedBy(),
+            steps
+        );
+    }
+}

--- a/src/main/java/com/cmms11/approval/ApprovalService.java
+++ b/src/main/java/com/cmms11/approval/ApprovalService.java
@@ -1,0 +1,170 @@
+package com.cmms11.approval;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: ApprovalService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 헤더 및 단계 CRUD 로직을 담당하는 서비스.
+ */
+@Service
+@Transactional
+public class ApprovalService {
+
+    private static final String MODULE_CODE = "A";
+
+    private final ApprovalRepository repository;
+    private final ApprovalStepRepository stepRepository;
+    private final AutoNumberService autoNumberService;
+
+    public ApprovalService(
+        ApprovalRepository repository,
+        ApprovalStepRepository stepRepository,
+        AutoNumberService autoNumberService
+    ) {
+        this.repository = repository;
+        this.stepRepository = stepRepository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ApprovalResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Approval> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyId(companyId, pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, trimmed, pageable);
+        }
+        return page.map(approval -> ApprovalResponse.from(approval, Collections.emptyList()));
+    }
+
+    @Transactional(readOnly = true)
+    public ApprovalResponse get(String approvalId) {
+        Approval approval = getExisting(approvalId);
+        List<ApprovalStepResponse> steps = stepRepository
+            .findByIdCompanyIdAndIdApprovalIdOrderByIdStepNo(MemberUserDetailsService.DEFAULT_COMPANY, approvalId)
+            .stream()
+            .map(ApprovalStepResponse::from)
+            .collect(Collectors.toList());
+        return ApprovalResponse.from(approval, steps);
+    }
+
+    public ApprovalResponse create(ApprovalRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        String newId = resolveId(companyId, request.approvalId());
+        Approval entity = new Approval();
+        entity.setId(new ApprovalId(companyId, newId));
+        entity.setCreatedAt(now);
+        entity.setCreatedBy(memberId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+        Approval saved = repository.save(entity);
+
+        replaceSteps(companyId, newId, request.steps());
+        List<ApprovalStepResponse> steps = stepRepository
+            .findByIdCompanyIdAndIdApprovalIdOrderByIdStepNo(companyId, newId)
+            .stream()
+            .map(ApprovalStepResponse::from)
+            .collect(Collectors.toList());
+        return ApprovalResponse.from(saved, steps);
+    }
+
+    public ApprovalResponse update(String approvalId, ApprovalRequest request) {
+        Approval entity = getExisting(approvalId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        Approval saved = repository.save(entity);
+
+        replaceSteps(MemberUserDetailsService.DEFAULT_COMPANY, approvalId, request.steps());
+        List<ApprovalStepResponse> steps = stepRepository
+            .findByIdCompanyIdAndIdApprovalIdOrderByIdStepNo(MemberUserDetailsService.DEFAULT_COMPANY, approvalId)
+            .stream()
+            .map(ApprovalStepResponse::from)
+            .collect(Collectors.toList());
+        return ApprovalResponse.from(saved, steps);
+    }
+
+    public void delete(String approvalId) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        stepRepository.deleteByIdCompanyIdAndIdApprovalId(companyId, approvalId);
+        Approval entity = getExisting(approvalId);
+        repository.delete(entity);
+    }
+
+    private Approval getExisting(String approvalId) {
+        return repository
+            .findByIdCompanyIdAndIdApprovalId(MemberUserDetailsService.DEFAULT_COMPANY, approvalId)
+            .orElseThrow(() -> new NotFoundException("Approval not found: " + approvalId));
+    }
+
+    private void applyRequest(Approval entity, ApprovalRequest request) {
+        entity.setTitle(request.title());
+        entity.setStatus(request.status());
+        entity.setRefEntity(request.refEntity());
+        entity.setRefId(request.refId());
+        entity.setContent(request.content());
+        entity.setFileGroupId(request.fileGroupId());
+    }
+
+    private void replaceSteps(String companyId, String approvalId, List<ApprovalStepRequest> steps) {
+        stepRepository.deleteByIdCompanyIdAndIdApprovalId(companyId, approvalId);
+        if (steps == null || steps.isEmpty()) {
+            return;
+        }
+        for (int i = 0; i < steps.size(); i++) {
+            ApprovalStepRequest request = steps.get(i);
+            int stepNo = request.stepNo() != null && request.stepNo() > 0 ? request.stepNo() : (i + 1);
+            ApprovalStep step = new ApprovalStep();
+            step.setId(new ApprovalStepId(companyId, approvalId, stepNo));
+            step.setMemberId(request.memberId());
+            step.setDecision(request.decision());
+            step.setDecidedAt(request.decidedAt());
+            step.setComment(request.comment());
+            stepRepository.save(step);
+        }
+    }
+
+    private String resolveId(String companyId, String requestedId) {
+        if (requestedId != null && !requestedId.isBlank()) {
+            String trimmed = requestedId.trim();
+            repository
+                .findByIdCompanyIdAndIdApprovalId(companyId, trimmed)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Approval already exists: " + trimmed);
+                });
+            return trimmed;
+        }
+        return autoNumberService.generateTxId(companyId, MODULE_CODE, LocalDate.now());
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/java/com/cmms11/approval/ApprovalStep.java
+++ b/src/main/java/com/cmms11/approval/ApprovalStep.java
@@ -1,0 +1,40 @@
+package com.cmms11.approval;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: ApprovalStep
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 단계 엔티티.
+ */
+@Entity
+@Table(name = "approval_step")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApprovalStep {
+
+    @EmbeddedId
+    private ApprovalStepId id;
+
+    @Column(name = "member_id", length = 5)
+    private String memberId;
+
+    @Column(length = 5)
+    private String decision;
+
+    @Column(name = "decided_at")
+    private LocalDateTime decidedAt;
+
+    @Column(length = 500)
+    private String comment;
+}

--- a/src/main/java/com/cmms11/approval/ApprovalStepId.java
+++ b/src/main/java/com/cmms11/approval/ApprovalStepId.java
@@ -1,0 +1,35 @@
+package com.cmms11.approval;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: ApprovalStepId
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 단계 복합키.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ApprovalStepId implements Serializable {
+
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "approval_id", length = 10, nullable = false)
+    private String approvalId;
+
+    @Column(name = "step_no", nullable = false)
+    private Integer stepNo;
+}

--- a/src/main/java/com/cmms11/approval/ApprovalStepRepository.java
+++ b/src/main/java/com/cmms11/approval/ApprovalStepRepository.java
@@ -1,0 +1,18 @@
+package com.cmms11.approval;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: ApprovalStepRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 단계 엔티티용 JPA 레포지토리.
+ */
+public interface ApprovalStepRepository extends JpaRepository<ApprovalStep, ApprovalStepId> {
+
+    List<ApprovalStep> findByIdCompanyIdAndIdApprovalIdOrderByIdStepNo(String companyId, String approvalId);
+
+    void deleteByIdCompanyIdAndIdApprovalId(String companyId, String approvalId);
+}

--- a/src/main/java/com/cmms11/approval/ApprovalStepRequest.java
+++ b/src/main/java/com/cmms11/approval/ApprovalStepRequest.java
@@ -1,0 +1,21 @@
+package com.cmms11.approval;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+/**
+ * 이름: ApprovalStepRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 단계 요청 DTO.
+ */
+public record ApprovalStepRequest(
+    Integer stepNo,
+    @NotBlank @Size(max = 5) String memberId,
+    @Size(max = 5) String decision,
+    LocalDateTime decidedAt,
+    @Size(max = 500) String comment
+) {
+}

--- a/src/main/java/com/cmms11/approval/ApprovalStepResponse.java
+++ b/src/main/java/com/cmms11/approval/ApprovalStepResponse.java
@@ -1,0 +1,29 @@
+package com.cmms11.approval;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: ApprovalStepResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 결재 단계 응답 DTO.
+ */
+public record ApprovalStepResponse(
+    Integer stepNo,
+    String memberId,
+    String decision,
+    LocalDateTime decidedAt,
+    String comment
+) {
+    public static ApprovalStepResponse from(ApprovalStep step) {
+        Integer stepNo = step.getId() != null ? step.getId().getStepNo() : null;
+        return new ApprovalStepResponse(
+            stepNo,
+            step.getMemberId(),
+            step.getDecision(),
+            step.getDecidedAt(),
+            step.getComment()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/code/CodeItemRepository.java
+++ b/src/main/java/com/cmms11/code/CodeItemRepository.java
@@ -1,11 +1,31 @@
 package com.cmms11.code;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 이름: CodeItemRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 항목(CodeItem) 접근 레포지토리.
+ */
 public interface CodeItemRepository extends JpaRepository<CodeItem, CodeItemId> {
-    Page<CodeItem> findByIdCodeType(String codeType, Pageable pageable);
-    Page<CodeItem> findByIdCodeTypeAndNameContainingIgnoreCase(String codeType, String q, Pageable pageable);
+
+    Page<CodeItem> findByIdCompanyIdAndIdCodeType(String companyId, String codeType, Pageable pageable);
+
+    Page<CodeItem> findByIdCompanyIdAndIdCodeTypeAndNameContainingIgnoreCase(
+        String companyId,
+        String codeType,
+        String name,
+        Pageable pageable
+    );
+
+    List<CodeItem> findByIdCompanyIdAndIdCodeType(String companyId, String codeType);
+
+    Optional<CodeItem> findByIdCompanyIdAndIdCodeTypeAndIdCode(String companyId, String codeType, String code);
 }
 

--- a/src/main/java/com/cmms11/code/CodeItemRequest.java
+++ b/src/main/java/com/cmms11/code/CodeItemRequest.java
@@ -1,0 +1,20 @@
+package com.cmms11.code;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: CodeItemRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 항목 생성/수정 요청 DTO.
+ */
+public record CodeItemRequest(
+    @NotBlank @Size(max = 5) String codeType,
+    @NotBlank @Size(max = 5) String code,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/code/CodeItemResponse.java
+++ b/src/main/java/com/cmms11/code/CodeItemResponse.java
@@ -1,0 +1,26 @@
+package com.cmms11.code;
+
+/**
+ * 이름: CodeItemResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 항목 응답 DTO.
+ */
+public record CodeItemResponse(
+    String codeType,
+    String code,
+    String name,
+    String note
+) {
+
+    public static CodeItemResponse from(CodeItem item) {
+        return new CodeItemResponse(
+            item.getId().getCodeType(),
+            item.getId().getCode(),
+            item.getName(),
+            item.getNote()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/code/CodeService.java
+++ b/src/main/java/com/cmms11/code/CodeService.java
@@ -1,0 +1,183 @@
+package com.cmms11.code;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: CodeService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 타입/항목 CRUD 비즈니스 로직 구현.
+ */
+@Service
+@Transactional
+public class CodeService {
+
+    private final CodeTypeRepository typeRepository;
+    private final CodeItemRepository itemRepository;
+
+    public CodeService(CodeTypeRepository typeRepository, CodeItemRepository itemRepository) {
+        this.typeRepository = typeRepository;
+        this.itemRepository = itemRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CodeTypeResponse> listTypes(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<CodeType> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = typeRepository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            page = typeRepository.findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+                companyId,
+                "N",
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(CodeTypeResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public CodeTypeResponse getType(String codeType) {
+        return CodeTypeResponse.from(getActiveType(codeType));
+    }
+
+    public CodeTypeResponse createType(CodeTypeRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Optional<CodeType> existing = typeRepository.findByIdCompanyIdAndIdCodeType(companyId, request.codeType());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            CodeType type = existing.get();
+            if (!"Y".equalsIgnoreCase(type.getDeleteMark())) {
+                throw new IllegalArgumentException("Code type already exists: " + request.codeType());
+            }
+            type.setName(request.name());
+            type.setNote(request.note());
+            type.setDeleteMark("N");
+            type.setUpdatedAt(now);
+            type.setUpdatedBy(memberId);
+            return CodeTypeResponse.from(typeRepository.save(type));
+        }
+
+        CodeType type = new CodeType();
+        type.setId(new CodeTypeId(companyId, request.codeType()));
+        type.setName(request.name());
+        type.setNote(request.note());
+        type.setDeleteMark("N");
+        type.setCreatedAt(now);
+        type.setCreatedBy(memberId);
+        type.setUpdatedAt(now);
+        type.setUpdatedBy(memberId);
+        return CodeTypeResponse.from(typeRepository.save(type));
+    }
+
+    public CodeTypeResponse updateType(String codeType, CodeTypeRequest request) {
+        CodeType type = getActiveType(codeType);
+        type.setName(request.name());
+        type.setNote(request.note());
+        type.setUpdatedAt(LocalDateTime.now());
+        type.setUpdatedBy(currentMemberId());
+        return CodeTypeResponse.from(typeRepository.save(type));
+    }
+
+    public void deleteType(String codeType) {
+        CodeType type = getActiveType(codeType);
+        List<CodeItem> items = itemRepository.findByIdCompanyIdAndIdCodeType(type.getId().getCompanyId(), codeType);
+        if (!items.isEmpty()) {
+            throw new IllegalStateException("Cannot delete code type with existing items: " + codeType);
+        }
+        type.setDeleteMark("Y");
+        type.setUpdatedAt(LocalDateTime.now());
+        type.setUpdatedBy(currentMemberId());
+        typeRepository.save(type);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CodeItemResponse> listItems(String codeType, String keyword, Pageable pageable) {
+        CodeType type = getActiveType(codeType);
+        Page<CodeItem> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = itemRepository.findByIdCompanyIdAndIdCodeType(type.getId().getCompanyId(), codeType, pageable);
+        } else {
+            page = itemRepository.findByIdCompanyIdAndIdCodeTypeAndNameContainingIgnoreCase(
+                type.getId().getCompanyId(),
+                codeType,
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(CodeItemResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public CodeItemResponse getItem(String codeType, String code) {
+        return CodeItemResponse.from(getItemEntity(codeType, code));
+    }
+
+    public CodeItemResponse createItem(CodeItemRequest request) {
+        CodeType type = getActiveType(request.codeType());
+        Optional<CodeItem> existing = itemRepository.findByIdCompanyIdAndIdCodeTypeAndIdCode(
+            type.getId().getCompanyId(),
+            request.codeType(),
+            request.code()
+        );
+        if (existing.isPresent()) {
+            throw new IllegalArgumentException("Code item already exists: " + request.code());
+        }
+        CodeItem item = new CodeItem();
+        item.setId(new CodeItemId(type.getId().getCompanyId(), request.codeType(), request.code()));
+        item.setName(request.name());
+        item.setNote(request.note());
+        return CodeItemResponse.from(itemRepository.save(item));
+    }
+
+    public CodeItemResponse updateItem(String codeType, String code, CodeItemRequest request) {
+        CodeItem item = getItemEntity(codeType, code);
+        item.setName(request.name());
+        item.setNote(request.note());
+        return CodeItemResponse.from(itemRepository.save(item));
+    }
+
+    public void deleteItem(String codeType, String code) {
+        CodeItem item = getItemEntity(codeType, code);
+        itemRepository.delete(item);
+    }
+
+    private CodeType getActiveType(String codeType) {
+        return typeRepository.findByIdCompanyIdAndIdCodeType(MemberUserDetailsService.DEFAULT_COMPANY, codeType)
+            .filter(type -> !"Y".equalsIgnoreCase(type.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Code type not found: " + codeType));
+    }
+
+    private CodeItem getItemEntity(String codeType, String code) {
+        return itemRepository.findByIdCompanyIdAndIdCodeTypeAndIdCode(
+                MemberUserDetailsService.DEFAULT_COMPANY,
+                codeType,
+                code
+            )
+            .orElseThrow(() -> new NotFoundException("Code item not found: " + codeType + "/" + code));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/code/CodeTypeRepository.java
+++ b/src/main/java/com/cmms11/code/CodeTypeRepository.java
@@ -1,10 +1,28 @@
 package com.cmms11.code;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 이름: CodeTypeRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 타입 영속성 접근 레포지토리.
+ */
 public interface CodeTypeRepository extends JpaRepository<CodeType, CodeTypeId> {
-    Page<CodeType> findByNameContainingIgnoreCase(String q, Pageable pageable);
+
+    Page<CodeType> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    Page<CodeType> findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+        String companyId,
+        String deleteMark,
+        String name,
+        Pageable pageable
+    );
+
+    Optional<CodeType> findByIdCompanyIdAndIdCodeType(String companyId, String codeType);
 }
 

--- a/src/main/java/com/cmms11/code/CodeTypeRequest.java
+++ b/src/main/java/com/cmms11/code/CodeTypeRequest.java
@@ -1,0 +1,19 @@
+package com.cmms11.code;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: CodeTypeRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 타입 생성/수정 요청 DTO.
+ */
+public record CodeTypeRequest(
+    @NotBlank @Size(max = 5) String codeType,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/code/CodeTypeResponse.java
+++ b/src/main/java/com/cmms11/code/CodeTypeResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.code;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: CodeTypeResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 타입 응답 DTO.
+ */
+public record CodeTypeResponse(
+    String codeType,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static CodeTypeResponse from(CodeType type) {
+        return new CodeTypeResponse(
+            type.getId().getCodeType(),
+            type.getName(),
+            type.getNote(),
+            type.getDeleteMark(),
+            type.getCreatedAt(),
+            type.getCreatedBy(),
+            type.getUpdatedAt(),
+            type.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/common/error/ApiErrorResponse.java
+++ b/src/main/java/com/cmms11/common/error/ApiErrorResponse.java
@@ -1,0 +1,47 @@
+package com.cmms11.common.error;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 이름: ApiErrorResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: REST API 예외 응답 페이로드 정의.
+ */
+public record ApiErrorResponse(
+    LocalDateTime timestamp,
+    int status,
+    String error,
+    String message,
+    String path,
+    List<ApiFieldError> fieldErrors
+) {
+
+    public static ApiErrorResponse of(int status, String error, String message, String path) {
+        return new ApiErrorResponse(LocalDateTime.now(), status, error, message, path, Collections.emptyList());
+    }
+
+    public static ApiErrorResponse of(
+        int status,
+        String error,
+        String message,
+        String path,
+        List<ApiFieldError> fieldErrors
+    ) {
+        return new ApiErrorResponse(LocalDateTime.now(), status, error, message, path, fieldErrors);
+    }
+
+    /**
+     * 이름: ApiFieldError
+     * 작성자: codex
+     * 작성일: 2025-08-20
+     * 수정일:
+     * 프로그램 개요: 필드 단위 Validation 오류 정보를 표현.
+     */
+    public record ApiFieldError(String field, String message, Object rejectedValue) {
+    }
+}
+

--- a/src/main/java/com/cmms11/common/error/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/cmms11/common/error/GlobalRestExceptionHandler.java
@@ -1,0 +1,79 @@
+package com.cmms11.common.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 이름: GlobalRestExceptionHandler
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 예외를 가로채어 표준화된 API 응답을 생성하는 핸들러.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalRestExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(NotFoundException ex, HttpServletRequest request) {
+        log.warn("Resource not found: {}", ex.getMessage());
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        ApiErrorResponse body = ApiErrorResponse.of(status.value(), status.getReasonPhrase(), ex.getMessage(), request.getRequestURI());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        List<ApiErrorResponse.ApiFieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+            .map(this::toFieldError)
+            .collect(Collectors.toList());
+        ApiErrorResponse body = ApiErrorResponse.of(
+            status.value(),
+            status.getReasonPhrase(),
+            "Validation failed",
+            request.getRequestURI(),
+            fieldErrors
+        );
+        log.warn("Validation error on {}: {}", request.getRequestURI(), fieldErrors);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    public ResponseEntity<ApiErrorResponse> handleBadRequest(RuntimeException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ApiErrorResponse body = ApiErrorResponse.of(status.value(), status.getReasonPhrase(), ex.getMessage(), request.getRequestURI());
+        log.warn("Business rule violation on {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.FORBIDDEN;
+        ApiErrorResponse body = ApiErrorResponse.of(status.value(), status.getReasonPhrase(), ex.getMessage(), request.getRequestURI());
+        log.warn("Access denied on {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleGeneric(Exception ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        ApiErrorResponse body = ApiErrorResponse.of(status.value(), status.getReasonPhrase(), "Internal server error", request.getRequestURI());
+        log.error("Unexpected error on {}", request.getRequestURI(), ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    private ApiErrorResponse.ApiFieldError toFieldError(FieldError fieldError) {
+        return new ApiErrorResponse.ApiFieldError(fieldError.getField(), fieldError.getDefaultMessage(), fieldError.getRejectedValue());
+    }
+}
+

--- a/src/main/java/com/cmms11/config/RequestLoggingFilter.java
+++ b/src/main/java/com/cmms11/config/RequestLoggingFilter.java
@@ -1,0 +1,36 @@
+package com.cmms11.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 이름: RequestLoggingFilter
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: HTTP 요청/응답 메타데이터를 로깅하여 감사 추적을 지원하는 필터.
+ */
+@Slf4j
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        long started = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - started;
+            log.info("[REQ] {} {} status={} duration={}ms", request.getMethod(), request.getRequestURI(), response.getStatus(), elapsed);
+        }
+    }
+}
+

--- a/src/main/java/com/cmms11/config/SecurityConfig.java
+++ b/src/main/java/com/cmms11/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.cmms11.config;
 
+import com.cmms11.security.CsrfCookieFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -10,15 +11,35 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
+/**
+ * 이름: SecurityConfig
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: Spring Security 전역 설정 및 CSRF/로그 필터 구성.
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        csrfTokenRepository.setCookiePath("/");
+
+        CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
+        requestHandler.setCsrfRequestAttributeName("_csrf");
+
         http
-            .csrf(csrf -> csrf.disable()) // TODO: enable and add CSRF tokens for forms
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(csrfTokenRepository)
+                .csrfTokenRequestHandler(requestHandler)
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                     "/auth/**",
@@ -46,6 +67,11 @@ public class SecurityConfig {
                 .invalidateHttpSession(true)
                 .deleteCookies("JSESSIONID")
             );
+
+        http
+            .addFilterBefore(new RequestLoggingFilter(), UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class);
+
         return http.build();
     }
 

--- a/src/main/java/com/cmms11/domain/company/CompanyRepository.java
+++ b/src/main/java/com/cmms11/domain/company/CompanyRepository.java
@@ -1,0 +1,23 @@
+package com.cmms11.domain.company;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: CompanyRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 엔티티에 대한 기본 CRUD 및 조회 메서드를 제공하는 JPA 레포지토리.
+ */
+public interface CompanyRepository extends JpaRepository<Company, String> {
+
+    Page<Company> findByDeleteMark(String deleteMark, Pageable pageable);
+
+    Page<Company> findByDeleteMarkAndNameContainingIgnoreCase(String deleteMark, String name, Pageable pageable);
+
+    Optional<Company> findByCompanyIdAndDeleteMark(String companyId, String deleteMark);
+}
+

--- a/src/main/java/com/cmms11/domain/company/CompanyRequest.java
+++ b/src/main/java/com/cmms11/domain/company/CompanyRequest.java
@@ -1,0 +1,27 @@
+package com.cmms11.domain.company;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: CompanyRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 생성/수정 요청에 대한 DTO.
+ */
+public record CompanyRequest(
+    @NotBlank @Size(max = 5) String companyId,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+
+    public Company toEntity() {
+        Company company = new Company();
+        company.setCompanyId(companyId);
+        company.setName(name);
+        company.setNote(note);
+        return company;
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/company/CompanyResponse.java
+++ b/src/main/java/com/cmms11/domain/company/CompanyResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.domain.company;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: CompanyResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 조회 응답 DTO.
+ */
+public record CompanyResponse(
+    String companyId,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static CompanyResponse from(Company entity) {
+        return new CompanyResponse(
+            entity.getCompanyId(),
+            entity.getName(),
+            entity.getNote(),
+            entity.getDeleteMark(),
+            entity.getCreatedAt(),
+            entity.getCreatedBy(),
+            entity.getUpdatedAt(),
+            entity.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/company/CompanyService.java
+++ b/src/main/java/com/cmms11/domain/company/CompanyService.java
@@ -1,0 +1,104 @@
+package com.cmms11.domain.company;
+
+import com.cmms11.common.error.NotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: CompanyService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 기준정보 CRUD 및 조회 로직을 처리하는 서비스.
+ */
+@Service
+@Transactional
+public class CompanyService {
+
+    private final CompanyRepository repository;
+
+    public CompanyService(CompanyRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CompanyResponse> list(String keyword, Pageable pageable) {
+        Page<Company> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByDeleteMark("N", pageable);
+        } else {
+            page = repository.findByDeleteMarkAndNameContainingIgnoreCase("N", keyword.trim(), pageable);
+        }
+        return page.map(CompanyResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public CompanyResponse get(String companyId) {
+        return CompanyResponse.from(getActiveCompany(companyId));
+    }
+
+    public CompanyResponse create(CompanyRequest request) {
+        Optional<Company> existing = repository.findById(request.companyId());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            Company entity = existing.get();
+            if (!"Y".equalsIgnoreCase(entity.getDeleteMark())) {
+                throw new IllegalArgumentException("Company already exists: " + request.companyId());
+            }
+            entity.setName(request.name());
+            entity.setNote(request.note());
+            entity.setDeleteMark("N");
+            entity.setUpdatedAt(now);
+            entity.setUpdatedBy(memberId);
+            return CompanyResponse.from(repository.save(entity));
+        }
+
+        Company company = request.toEntity();
+        company.setDeleteMark("N");
+        company.setCreatedAt(now);
+        company.setCreatedBy(memberId);
+        company.setUpdatedAt(now);
+        company.setUpdatedBy(memberId);
+        return CompanyResponse.from(repository.save(company));
+    }
+
+    public CompanyResponse update(String companyId, CompanyRequest request) {
+        Company existing = getActiveCompany(companyId);
+        existing.setName(request.name());
+        existing.setNote(request.note());
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        return CompanyResponse.from(repository.save(existing));
+    }
+
+    public void delete(String companyId) {
+        Company existing = getActiveCompany(companyId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private Company getActiveCompany(String companyId) {
+        return repository.findByCompanyIdAndDeleteMark(companyId, "N")
+            .orElseThrow(() -> new NotFoundException("Company not found: " + companyId));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/dept/DeptRepository.java
+++ b/src/main/java/com/cmms11/domain/dept/DeptRepository.java
@@ -1,0 +1,28 @@
+package com.cmms11.domain.dept;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: DeptRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 부서(Dept) 엔티티 조회를 담당하는 JPA 레포지토리.
+ */
+public interface DeptRepository extends JpaRepository<Dept, DeptId> {
+
+    Page<Dept> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    Page<Dept> findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+        String companyId,
+        String deleteMark,
+        String name,
+        Pageable pageable
+    );
+
+    Optional<Dept> findByIdCompanyIdAndIdDeptId(String companyId, String deptId);
+}
+

--- a/src/main/java/com/cmms11/domain/dept/DeptRequest.java
+++ b/src/main/java/com/cmms11/domain/dept/DeptRequest.java
@@ -1,0 +1,19 @@
+package com.cmms11.domain.dept;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: DeptRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 부서 생성/수정 요청 DTO.
+ */
+public record DeptRequest(
+    @NotBlank @Size(max = 5) String deptId,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/domain/dept/DeptResponse.java
+++ b/src/main/java/com/cmms11/domain/dept/DeptResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.domain.dept;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: DeptResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 부서 조회 응답 DTO.
+ */
+public record DeptResponse(
+    String deptId,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static DeptResponse from(Dept dept) {
+        return new DeptResponse(
+            dept.getId().getDeptId(),
+            dept.getName(),
+            dept.getNote(),
+            dept.getDeleteMark(),
+            dept.getCreatedAt(),
+            dept.getCreatedBy(),
+            dept.getUpdatedAt(),
+            dept.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/dept/DeptService.java
+++ b/src/main/java/com/cmms11/domain/dept/DeptService.java
@@ -1,0 +1,116 @@
+package com.cmms11.domain.dept;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: DeptService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 부서 기준정보의 CRUD 비즈니스 로직 처리.
+ */
+@Service
+@Transactional
+public class DeptService {
+
+    private final DeptRepository repository;
+
+    public DeptService(DeptRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DeptResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Dept> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            page = repository.findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+                companyId,
+                "N",
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(DeptResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public DeptResponse get(String deptId) {
+        return DeptResponse.from(getActiveDept(deptId));
+    }
+
+    public DeptResponse create(DeptRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Optional<Dept> existing = repository.findByIdCompanyIdAndIdDeptId(companyId, request.deptId());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            Dept dept = existing.get();
+            if (!"Y".equalsIgnoreCase(dept.getDeleteMark())) {
+                throw new IllegalArgumentException("Dept already exists: " + request.deptId());
+            }
+            dept.setName(request.name());
+            dept.setNote(request.note());
+            dept.setDeleteMark("N");
+            dept.setUpdatedAt(now);
+            dept.setUpdatedBy(memberId);
+            return DeptResponse.from(repository.save(dept));
+        }
+
+        Dept dept = new Dept();
+        dept.setId(new DeptId(companyId, request.deptId()));
+        dept.setName(request.name());
+        dept.setNote(request.note());
+        dept.setDeleteMark("N");
+        dept.setCreatedAt(now);
+        dept.setCreatedBy(memberId);
+        dept.setUpdatedAt(now);
+        dept.setUpdatedBy(memberId);
+        return DeptResponse.from(repository.save(dept));
+    }
+
+    public DeptResponse update(String deptId, DeptRequest request) {
+        Dept existing = getActiveDept(deptId);
+        existing.setName(request.name());
+        existing.setNote(request.note());
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        return DeptResponse.from(repository.save(existing));
+    }
+
+    public void delete(String deptId) {
+        Dept existing = getActiveDept(deptId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private Dept getActiveDept(String deptId) {
+        return repository.findByIdCompanyIdAndIdDeptId(MemberUserDetailsService.DEFAULT_COMPANY, deptId)
+            .filter(dept -> !"Y".equalsIgnoreCase(dept.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Dept not found: " + deptId));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/func/Func.java
+++ b/src/main/java/com/cmms11/domain/func/Func.java
@@ -1,0 +1,50 @@
+package com.cmms11.domain.func;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: Func
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치(domain func) 엔티티.
+ */
+@Entity
+@Table(name = "func")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Func {
+
+    @EmbeddedId
+    private FuncId id;
+
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String note;
+
+    @Column(name = "delete_mark", length = 1)
+    private String deleteMark = "N";
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", length = 10)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 10)
+    private String updatedBy;
+}
+

--- a/src/main/java/com/cmms11/domain/func/FuncId.java
+++ b/src/main/java/com/cmms11/domain/func/FuncId.java
@@ -1,0 +1,33 @@
+package com.cmms11.domain.func;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: FuncId
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 식별자 복합키 정의.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class FuncId implements Serializable {
+
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "func_id", length = 5, nullable = false)
+    private String funcId;
+}
+

--- a/src/main/java/com/cmms11/domain/func/FuncRepository.java
+++ b/src/main/java/com/cmms11/domain/func/FuncRepository.java
@@ -1,0 +1,28 @@
+package com.cmms11.domain.func;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: FuncRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 엔티티 영속성 접근 인터페이스.
+ */
+public interface FuncRepository extends JpaRepository<Func, FuncId> {
+
+    Page<Func> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    Page<Func> findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+        String companyId,
+        String deleteMark,
+        String name,
+        Pageable pageable
+    );
+
+    Optional<Func> findByIdCompanyIdAndIdFuncId(String companyId, String funcId);
+}
+

--- a/src/main/java/com/cmms11/domain/func/FuncRequest.java
+++ b/src/main/java/com/cmms11/domain/func/FuncRequest.java
@@ -1,0 +1,19 @@
+package com.cmms11.domain.func;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: FuncRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 생성/수정 요청 DTO.
+ */
+public record FuncRequest(
+    @NotBlank @Size(max = 5) String funcId,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/domain/func/FuncResponse.java
+++ b/src/main/java/com/cmms11/domain/func/FuncResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.domain.func;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: FuncResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 조회 응답 DTO.
+ */
+public record FuncResponse(
+    String funcId,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static FuncResponse from(Func func) {
+        return new FuncResponse(
+            func.getId().getFuncId(),
+            func.getName(),
+            func.getNote(),
+            func.getDeleteMark(),
+            func.getCreatedAt(),
+            func.getCreatedBy(),
+            func.getUpdatedAt(),
+            func.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/func/FuncService.java
+++ b/src/main/java/com/cmms11/domain/func/FuncService.java
@@ -1,0 +1,116 @@
+package com.cmms11.domain.func;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: FuncService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 CRUD 비즈니스 로직 구현.
+ */
+@Service
+@Transactional
+public class FuncService {
+
+    private final FuncRepository repository;
+
+    public FuncService(FuncRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<FuncResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Func> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            page = repository.findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+                companyId,
+                "N",
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(FuncResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public FuncResponse get(String funcId) {
+        return FuncResponse.from(getActiveFunc(funcId));
+    }
+
+    public FuncResponse create(FuncRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Optional<Func> existing = repository.findByIdCompanyIdAndIdFuncId(companyId, request.funcId());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            Func func = existing.get();
+            if (!"Y".equalsIgnoreCase(func.getDeleteMark())) {
+                throw new IllegalArgumentException("Func already exists: " + request.funcId());
+            }
+            func.setName(request.name());
+            func.setNote(request.note());
+            func.setDeleteMark("N");
+            func.setUpdatedAt(now);
+            func.setUpdatedBy(memberId);
+            return FuncResponse.from(repository.save(func));
+        }
+
+        Func func = new Func();
+        func.setId(new FuncId(companyId, request.funcId()));
+        func.setName(request.name());
+        func.setNote(request.note());
+        func.setDeleteMark("N");
+        func.setCreatedAt(now);
+        func.setCreatedBy(memberId);
+        func.setUpdatedAt(now);
+        func.setUpdatedBy(memberId);
+        return FuncResponse.from(repository.save(func));
+    }
+
+    public FuncResponse update(String funcId, FuncRequest request) {
+        Func existing = getActiveFunc(funcId);
+        existing.setName(request.name());
+        existing.setNote(request.note());
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        return FuncResponse.from(repository.save(existing));
+    }
+
+    public void delete(String funcId) {
+        Func existing = getActiveFunc(funcId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private Func getActiveFunc(String funcId) {
+        return repository.findByIdCompanyIdAndIdFuncId(MemberUserDetailsService.DEFAULT_COMPANY, funcId)
+            .filter(func -> !"Y".equalsIgnoreCase(func.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Func not found: " + funcId));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/site/SiteRepository.java
+++ b/src/main/java/com/cmms11/domain/site/SiteRepository.java
@@ -1,0 +1,28 @@
+package com.cmms11.domain.site;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: SiteRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 사업장(Site) 엔티티 조회를 지원하는 JPA 레포지토리.
+ */
+public interface SiteRepository extends JpaRepository<Site, SiteId> {
+
+    Page<Site> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    Page<Site> findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+        String companyId,
+        String deleteMark,
+        String name,
+        Pageable pageable
+    );
+
+    Optional<Site> findByIdCompanyIdAndIdSiteId(String companyId, String siteId);
+}
+

--- a/src/main/java/com/cmms11/domain/site/SiteRequest.java
+++ b/src/main/java/com/cmms11/domain/site/SiteRequest.java
@@ -1,0 +1,19 @@
+package com.cmms11.domain.site;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: SiteRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 사업장 생성/수정 요청 DTO.
+ */
+public record SiteRequest(
+    @NotBlank @Size(max = 5) String siteId,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/domain/site/SiteResponse.java
+++ b/src/main/java/com/cmms11/domain/site/SiteResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.domain.site;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: SiteResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 사업장 조회 응답 DTO.
+ */
+public record SiteResponse(
+    String siteId,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static SiteResponse from(Site site) {
+        return new SiteResponse(
+            site.getId().getSiteId(),
+            site.getName(),
+            site.getNote(),
+            site.getDeleteMark(),
+            site.getCreatedAt(),
+            site.getCreatedBy(),
+            site.getUpdatedAt(),
+            site.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/site/SiteService.java
+++ b/src/main/java/com/cmms11/domain/site/SiteService.java
@@ -1,0 +1,116 @@
+package com.cmms11.domain.site;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: SiteService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 사업장 기준정보의 CRUD 로직을 담당하는 서비스.
+ */
+@Service
+@Transactional
+public class SiteService {
+
+    private final SiteRepository repository;
+
+    public SiteService(SiteRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SiteResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Site> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            page = repository.findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+                companyId,
+                "N",
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(SiteResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public SiteResponse get(String siteId) {
+        return SiteResponse.from(getActiveSite(siteId));
+    }
+
+    public SiteResponse create(SiteRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Optional<Site> existing = repository.findByIdCompanyIdAndIdSiteId(companyId, request.siteId());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            Site entity = existing.get();
+            if (!"Y".equalsIgnoreCase(entity.getDeleteMark())) {
+                throw new IllegalArgumentException("Site already exists: " + request.siteId());
+            }
+            entity.setName(request.name());
+            entity.setNote(request.note());
+            entity.setDeleteMark("N");
+            entity.setUpdatedAt(now);
+            entity.setUpdatedBy(memberId);
+            return SiteResponse.from(repository.save(entity));
+        }
+
+        Site site = new Site();
+        site.setId(new SiteId(companyId, request.siteId()));
+        site.setName(request.name());
+        site.setNote(request.note());
+        site.setDeleteMark("N");
+        site.setCreatedAt(now);
+        site.setCreatedBy(memberId);
+        site.setUpdatedAt(now);
+        site.setUpdatedBy(memberId);
+        return SiteResponse.from(repository.save(site));
+    }
+
+    public SiteResponse update(String siteId, SiteRequest request) {
+        Site existing = getActiveSite(siteId);
+        existing.setName(request.name());
+        existing.setNote(request.note());
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        return SiteResponse.from(repository.save(existing));
+    }
+
+    public void delete(String siteId) {
+        Site existing = getActiveSite(siteId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private Site getActiveSite(String siteId) {
+        return repository.findByIdCompanyIdAndIdSiteId(MemberUserDetailsService.DEFAULT_COMPANY, siteId)
+            .filter(site -> !"Y".equalsIgnoreCase(site.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Site not found: " + siteId));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/storage/Storage.java
+++ b/src/main/java/com/cmms11/domain/storage/Storage.java
@@ -1,0 +1,50 @@
+package com.cmms11.domain.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: Storage
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고(Storage) 엔티티 정의.
+ */
+@Entity
+@Table(name = "storage")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Storage {
+
+    @EmbeddedId
+    private StorageId id;
+
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String note;
+
+    @Column(name = "delete_mark", length = 1)
+    private String deleteMark = "N";
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", length = 10)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 10)
+    private String updatedBy;
+}
+

--- a/src/main/java/com/cmms11/domain/storage/StorageId.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageId.java
@@ -1,0 +1,33 @@
+package com.cmms11.domain.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이름: StorageId
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고(Storage) 복합키 정의.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class StorageId implements Serializable {
+
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "storage_id", length = 5, nullable = false)
+    private String storageId;
+}
+

--- a/src/main/java/com/cmms11/domain/storage/StorageRepository.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageRepository.java
@@ -1,0 +1,28 @@
+package com.cmms11.domain.storage;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름: StorageRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고(Storage) 엔티티 저장소.
+ */
+public interface StorageRepository extends JpaRepository<Storage, StorageId> {
+
+    Page<Storage> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    Page<Storage> findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+        String companyId,
+        String deleteMark,
+        String name,
+        Pageable pageable
+    );
+
+    Optional<Storage> findByIdCompanyIdAndIdStorageId(String companyId, String storageId);
+}
+

--- a/src/main/java/com/cmms11/domain/storage/StorageRequest.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageRequest.java
@@ -1,0 +1,19 @@
+package com.cmms11.domain.storage;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: StorageRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고 생성/수정 요청 DTO.
+ */
+public record StorageRequest(
+    @NotBlank @Size(max = 5) String storageId,
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 500) String note
+) {
+}
+

--- a/src/main/java/com/cmms11/domain/storage/StorageResponse.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageResponse.java
@@ -1,0 +1,36 @@
+package com.cmms11.domain.storage;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: StorageResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고 조회 응답 DTO.
+ */
+public record StorageResponse(
+    String storageId,
+    String name,
+    String note,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+    public static StorageResponse from(Storage storage) {
+        return new StorageResponse(
+            storage.getId().getStorageId(),
+            storage.getName(),
+            storage.getNote(),
+            storage.getDeleteMark(),
+            storage.getCreatedAt(),
+            storage.getCreatedBy(),
+            storage.getUpdatedAt(),
+            storage.getUpdatedBy()
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/domain/storage/StorageService.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageService.java
@@ -1,0 +1,116 @@
+package com.cmms11.domain.storage;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: StorageService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고 기준정보 CRUD 서비스.
+ */
+@Service
+@Transactional
+public class StorageService {
+
+    private final StorageRepository repository;
+
+    public StorageService(StorageRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StorageResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Storage> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            page = repository.findByIdCompanyIdAndDeleteMarkAndNameContainingIgnoreCase(
+                companyId,
+                "N",
+                keyword.trim(),
+                pageable
+            );
+        }
+        return page.map(StorageResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public StorageResponse get(String storageId) {
+        return StorageResponse.from(getActiveStorage(storageId));
+    }
+
+    public StorageResponse create(StorageRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Optional<Storage> existing = repository.findByIdCompanyIdAndIdStorageId(companyId, request.storageId());
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        if (existing.isPresent()) {
+            Storage storage = existing.get();
+            if (!"Y".equalsIgnoreCase(storage.getDeleteMark())) {
+                throw new IllegalArgumentException("Storage already exists: " + request.storageId());
+            }
+            storage.setName(request.name());
+            storage.setNote(request.note());
+            storage.setDeleteMark("N");
+            storage.setUpdatedAt(now);
+            storage.setUpdatedBy(memberId);
+            return StorageResponse.from(repository.save(storage));
+        }
+
+        Storage storage = new Storage();
+        storage.setId(new StorageId(companyId, request.storageId()));
+        storage.setName(request.name());
+        storage.setNote(request.note());
+        storage.setDeleteMark("N");
+        storage.setCreatedAt(now);
+        storage.setCreatedBy(memberId);
+        storage.setUpdatedAt(now);
+        storage.setUpdatedBy(memberId);
+        return StorageResponse.from(repository.save(storage));
+    }
+
+    public StorageResponse update(String storageId, StorageRequest request) {
+        Storage existing = getActiveStorage(storageId);
+        existing.setName(request.name());
+        existing.setNote(request.note());
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        return StorageResponse.from(repository.save(existing));
+    }
+
+    public void delete(String storageId) {
+        Storage existing = getActiveStorage(storageId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private Storage getActiveStorage(String storageId) {
+        return repository.findByIdCompanyIdAndIdStorageId(MemberUserDetailsService.DEFAULT_COMPANY, storageId)
+            .filter(storage -> !"Y".equalsIgnoreCase(storage.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Storage not found: " + storageId));
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}
+

--- a/src/main/java/com/cmms11/init/DataInitializer.java
+++ b/src/main/java/com/cmms11/init/DataInitializer.java
@@ -1,40 +1,206 @@
 package com.cmms11.init;
 
+import com.cmms11.code.CodeItem;
+import com.cmms11.code.CodeItemId;
+import com.cmms11.code.CodeItemRepository;
+import com.cmms11.code.CodeType;
+import com.cmms11.code.CodeTypeId;
+import com.cmms11.code.CodeTypeRepository;
+import com.cmms11.domain.company.Company;
+import com.cmms11.domain.company.CompanyRepository;
+import com.cmms11.domain.dept.Dept;
+import com.cmms11.domain.dept.DeptId;
+import com.cmms11.domain.dept.DeptRepository;
 import com.cmms11.domain.member.Member;
 import com.cmms11.domain.member.MemberId;
 import com.cmms11.domain.member.MemberRepository;
+import com.cmms11.domain.site.Site;
+import com.cmms11.domain.site.SiteId;
+import com.cmms11.domain.site.SiteRepository;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.stereotype.Component;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-
+/**
+ * 이름: DataInitializer
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 애플리케이션 기동 시 기본 데이터(Admin, 회사/사이트/부서, 공통코드)를 시드.
+ */
 @Component
 public class DataInitializer implements ApplicationRunner {
+    private static final String DEFAULT_COMPANY = "C0001";
+    private static final String SYSTEM_USER = "system";
+
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final CompanyRepository companyRepository;
+    private final SiteRepository siteRepository;
+    private final DeptRepository deptRepository;
+    private final CodeTypeRepository codeTypeRepository;
+    private final CodeItemRepository codeItemRepository;
 
-    public DataInitializer(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+    public DataInitializer(
+        MemberRepository memberRepository,
+        PasswordEncoder passwordEncoder,
+        CompanyRepository companyRepository,
+        SiteRepository siteRepository,
+        DeptRepository deptRepository,
+        CodeTypeRepository codeTypeRepository,
+        CodeItemRepository codeItemRepository
+    ) {
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
+        this.companyRepository = companyRepository;
+        this.siteRepository = siteRepository;
+        this.deptRepository = deptRepository;
+        this.codeTypeRepository = codeTypeRepository;
+        this.codeItemRepository = codeItemRepository;
     }
 
     @Override
-    public void run(ApplicationArguments args) throws Exception {
-        // Seed admin user for company C0001 with password 1234 (BCrypt)
-        MemberId adminId = new MemberId("C0001", "admin");
-        if (!memberRepository.existsById(adminId)) {
-            Member admin = new Member();
-            admin.setId(adminId);
-            admin.setName("Administrator");
-            admin.setDeptId("ADMIN");
-            admin.setPasswordHash(passwordEncoder.encode("1234"));
-            admin.setDeleteMark("N");
-            admin.setCreatedAt(LocalDateTime.now());
-            admin.setCreatedBy("system");
-            memberRepository.save(admin);
+    public void run(ApplicationArguments args) {
+        LocalDateTime now = LocalDateTime.now();
+        seedAdmin(now);
+        seedCompanyHierarchy(now);
+        seedCodes();
+    }
+
+    private void seedAdmin(LocalDateTime now) {
+        MemberId adminId = new MemberId(DEFAULT_COMPANY, "admin");
+        if (memberRepository.existsById(adminId)) {
+            return;
         }
+        Member admin = new Member();
+        admin.setId(adminId);
+        admin.setName("Administrator");
+        admin.setDeptId("ADMIN");
+        admin.setPasswordHash(passwordEncoder.encode("1234"));
+        admin.setDeleteMark("N");
+        admin.setCreatedAt(now);
+        admin.setCreatedBy(SYSTEM_USER);
+        admin.setUpdatedAt(now);
+        admin.setUpdatedBy(SYSTEM_USER);
+        memberRepository.save(admin);
+    }
+
+    private void seedCompanyHierarchy(LocalDateTime now) {
+        Company company = companyRepository.findById(DEFAULT_COMPANY).orElseGet(Company::new);
+        if (company.getCompanyId() == null) {
+            company.setCompanyId(DEFAULT_COMPANY);
+            company.setCreatedAt(now);
+            company.setCreatedBy(SYSTEM_USER);
+        }
+        company.setName("Sample Company");
+        company.setDeleteMark("N");
+        company.setUpdatedAt(now);
+        company.setUpdatedBy(SYSTEM_USER);
+        companyRepository.save(company);
+
+        List<Site> sites = List.of(
+            buildSite(now, "S0001", "Sample site1"),
+            buildSite(now, "S0002", "Sample site2")
+        );
+        sites.forEach(siteRepository::save);
+
+        List<Dept> depts = List.of(
+            buildDept(now, "D0001", "Sample department1"),
+            buildDept(now, "D0002", "Sample department2")
+        );
+        depts.forEach(deptRepository::save);
+    }
+
+    private Site buildSite(LocalDateTime now, String siteId, String name) {
+        SiteId id = new SiteId(DEFAULT_COMPANY, siteId);
+        Site site = siteRepository.findById(id).orElseGet(Site::new);
+        site.setId(id);
+        if (site.getCreatedAt() == null) {
+            site.setCreatedAt(now);
+            site.setCreatedBy(SYSTEM_USER);
+        }
+        site.setName(name);
+        site.setDeleteMark("N");
+        site.setUpdatedAt(now);
+        site.setUpdatedBy(SYSTEM_USER);
+        return site;
+    }
+
+    private Dept buildDept(LocalDateTime now, String deptId, String name) {
+        DeptId id = new DeptId(DEFAULT_COMPANY, deptId);
+        Dept dept = deptRepository.findById(id).orElseGet(Dept::new);
+        dept.setId(id);
+        if (dept.getCreatedAt() == null) {
+            dept.setCreatedAt(now);
+            dept.setCreatedBy(SYSTEM_USER);
+        }
+        dept.setName(name);
+        dept.setDeleteMark("N");
+        dept.setUpdatedAt(now);
+        dept.setUpdatedBy(SYSTEM_USER);
+        return dept;
+    }
+
+    private void seedCodes() {
+        Map<String, String> codeTypes = new LinkedHashMap<>();
+        codeTypes.put("ASSET", "자산유형");
+        codeTypes.put("JOBTP", "작업유형");
+        codeTypes.put("PERMT", "허가유형");
+
+        LocalDateTime now = LocalDateTime.now();
+        codeTypes.forEach((codeType, name) -> {
+            CodeType type = codeTypeRepository.findById(new CodeTypeId(DEFAULT_COMPANY, codeType))
+                .orElseGet(CodeType::new);
+            if (type.getId() == null) {
+                type.setId(new CodeTypeId(DEFAULT_COMPANY, codeType));
+                type.setCreatedAt(now);
+                type.setCreatedBy(SYSTEM_USER);
+            }
+            type.setName(name);
+            type.setDeleteMark("N");
+            type.setUpdatedAt(now);
+            type.setUpdatedBy(SYSTEM_USER);
+            codeTypeRepository.save(type);
+        });
+
+        seedItems("ASSET", List.of(
+            new SeedCodeItem("PLANT", "설비"),
+            new SeedCodeItem("OFFIC", "사무용품"),
+            new SeedCodeItem("INVET", "재고자산"),
+            new SeedCodeItem("TOOL", "공기구"),
+            new SeedCodeItem("BUILD", "건축물"),
+            new SeedCodeItem("ETC", "기타")
+        ));
+
+        seedItems("JOBTP", List.of(
+            new SeedCodeItem("PLI01", "정기점검"),
+            new SeedCodeItem("UPI01", "돌발점검"),
+            new SeedCodeItem("PLO01", "정기작업"),
+            new SeedCodeItem("UPO01", "돌발작업")
+        ));
+
+        seedItems("PERMT", List.of(
+            new SeedCodeItem("P0001", "허가1")
+        ));
+    }
+
+    private void seedItems(String codeType, List<SeedCodeItem> items) {
+        items.forEach(item -> {
+            CodeItemId id = new CodeItemId(DEFAULT_COMPANY, codeType, item.code());
+            CodeItem entity = codeItemRepository.findById(id).orElseGet(CodeItem::new);
+            entity.setId(id);
+            entity.setName(item.name());
+            entity.setNote(null);
+            codeItemRepository.save(entity);
+        });
+    }
+
+    private record SeedCodeItem(String code, String name) {
     }
 }
 

--- a/src/main/java/com/cmms11/inspection/InspectionRepository.java
+++ b/src/main/java/com/cmms11/inspection/InspectionRepository.java
@@ -1,0 +1,32 @@
+package com.cmms11.inspection;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: InspectionRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 예방점검 엔티티 CRUD 및 검색 기능을 제공하는 JPA 레포지토리.
+ */
+public interface InspectionRepository extends JpaRepository<Inspection, InspectionId> {
+
+    Page<Inspection> findByIdCompanyId(String companyId, Pageable pageable);
+
+    @Query(
+        "select i from Inspection i " +
+        "where i.id.companyId = :companyId and (i.id.inspectionId like :keyword or i.name like :keyword)"
+    )
+    Page<Inspection> search(
+        @Param("companyId") String companyId,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<Inspection> findByIdCompanyIdAndIdInspectionId(String companyId, String inspectionId);
+}

--- a/src/main/java/com/cmms11/inspection/InspectionRequest.java
+++ b/src/main/java/com/cmms11/inspection/InspectionRequest.java
@@ -1,0 +1,28 @@
+package com.cmms11.inspection;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+/**
+ * 이름: InspectionRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 예방점검 생성/수정 요청 DTO.
+ */
+public record InspectionRequest(
+    @Size(max = 10) String inspectionId,
+    @NotBlank @Size(max = 100) String name,
+    @NotBlank @Size(max = 10) String plantId,
+    @NotBlank @Size(max = 5) String jobId,
+    @NotBlank @Size(max = 5) String siteId,
+    @NotBlank @Size(max = 5) String deptId,
+    @Size(max = 5) String memberId,
+    LocalDate plannedDate,
+    LocalDate actualDate,
+    @Size(max = 10) String status,
+    @Size(max = 100) String fileGroupId,
+    @Size(max = 500) String note
+) {
+}

--- a/src/main/java/com/cmms11/inspection/InspectionResponse.java
+++ b/src/main/java/com/cmms11/inspection/InspectionResponse.java
@@ -1,0 +1,52 @@
+package com.cmms11.inspection;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 이름: InspectionResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 예방점검 응답 DTO.
+ */
+public record InspectionResponse(
+    String inspectionId,
+    String name,
+    String plantId,
+    String jobId,
+    String siteId,
+    String deptId,
+    String memberId,
+    LocalDate plannedDate,
+    LocalDate actualDate,
+    String status,
+    String fileGroupId,
+    String note,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+    public static InspectionResponse from(Inspection inspection) {
+        String inspectionId = inspection.getId() != null ? inspection.getId().getInspectionId() : null;
+        return new InspectionResponse(
+            inspectionId,
+            inspection.getName(),
+            inspection.getPlantId(),
+            inspection.getJobId(),
+            inspection.getSiteId(),
+            inspection.getDeptId(),
+            inspection.getMemberId(),
+            inspection.getPlannedDate(),
+            inspection.getActualDate(),
+            inspection.getStatus(),
+            inspection.getFileGroupId(),
+            inspection.getNote(),
+            inspection.getCreatedAt(),
+            inspection.getCreatedBy(),
+            inspection.getUpdatedAt(),
+            inspection.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/inspection/InspectionService.java
+++ b/src/main/java/com/cmms11/inspection/InspectionService.java
@@ -1,0 +1,127 @@
+package com.cmms11.inspection;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: InspectionService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 예방점검 트랜잭션 CRUD 로직을 담당하는 서비스.
+ */
+@Service
+@Transactional
+public class InspectionService {
+
+    private static final String MODULE_CODE = "I";
+
+    private final InspectionRepository repository;
+    private final AutoNumberService autoNumberService;
+
+    public InspectionService(InspectionRepository repository, AutoNumberService autoNumberService) {
+        this.repository = repository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<InspectionResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Inspection> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyId(companyId, pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, trimmed, pageable);
+        }
+        return page.map(InspectionResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public InspectionResponse get(String inspectionId) {
+        return InspectionResponse.from(getExisting(inspectionId));
+    }
+
+    public InspectionResponse create(InspectionRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        String newId = resolveId(companyId, request.inspectionId(), request.plannedDate());
+        Inspection entity = new Inspection();
+        entity.setId(new InspectionId(companyId, newId));
+        entity.setCreatedAt(now);
+        entity.setCreatedBy(memberId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+
+        Inspection saved = repository.save(entity);
+        return InspectionResponse.from(saved);
+    }
+
+    public InspectionResponse update(String inspectionId, InspectionRequest request) {
+        Inspection entity = getExisting(inspectionId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        return InspectionResponse.from(repository.save(entity));
+    }
+
+    public void delete(String inspectionId) {
+        Inspection entity = getExisting(inspectionId);
+        repository.delete(entity);
+    }
+
+    private Inspection getExisting(String inspectionId) {
+        return repository
+            .findByIdCompanyIdAndIdInspectionId(MemberUserDetailsService.DEFAULT_COMPANY, inspectionId)
+            .orElseThrow(() -> new NotFoundException("Inspection not found: " + inspectionId));
+    }
+
+    private void applyRequest(Inspection entity, InspectionRequest request) {
+        entity.setName(request.name());
+        entity.setPlantId(request.plantId());
+        entity.setJobId(request.jobId());
+        entity.setSiteId(request.siteId());
+        entity.setDeptId(request.deptId());
+        entity.setMemberId(request.memberId());
+        entity.setPlannedDate(request.plannedDate());
+        entity.setActualDate(request.actualDate());
+        entity.setStatus(request.status());
+        entity.setFileGroupId(request.fileGroupId());
+        entity.setNote(request.note());
+    }
+
+    private String resolveId(String companyId, String requestedId, LocalDate referenceDate) {
+        if (requestedId != null && !requestedId.isBlank()) {
+            String trimmed = requestedId.trim();
+            repository
+                .findByIdCompanyIdAndIdInspectionId(companyId, trimmed)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Inspection already exists: " + trimmed);
+                });
+            return trimmed;
+        }
+        LocalDate date = referenceDate != null ? referenceDate : LocalDate.now();
+        return autoNumberService.generateTxId(companyId, MODULE_CODE, date);
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/java/com/cmms11/inventory/InventoryRepository.java
+++ b/src/main/java/com/cmms11/inventory/InventoryRepository.java
@@ -1,0 +1,34 @@
+package com.cmms11.inventory;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: InventoryRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 재고 마스터 엔티티에 대한 기본 CRUD 및 검색 기능을 제공하는 JPA 레포지토리.
+ */
+public interface InventoryRepository extends JpaRepository<Inventory, InventoryId> {
+
+    Page<Inventory> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    @Query(
+        "select i from Inventory i " +
+        "where i.id.companyId = :companyId and i.deleteMark = :deleteMark " +
+        "and (i.id.inventoryId like :keyword or i.name like :keyword)"
+    )
+    Page<Inventory> search(
+        @Param("companyId") String companyId,
+        @Param("deleteMark") String deleteMark,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<Inventory> findByIdCompanyIdAndIdInventoryId(String companyId, String inventoryId);
+}

--- a/src/main/java/com/cmms11/inventory/InventoryRequest.java
+++ b/src/main/java/com/cmms11/inventory/InventoryRequest.java
@@ -1,0 +1,26 @@
+package com.cmms11.inventory;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: InventoryRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 재고 마스터 생성/수정 요청을 표현하는 DTO.
+ */
+public record InventoryRequest(
+    @Size(max = 10) String inventoryId,
+    @NotBlank @Size(max = 100) String name,
+    @NotBlank @Size(max = 5) String assetId,
+    @NotBlank @Size(max = 5) String deptId,
+    @Size(max = 100) String makerName,
+    @Size(max = 100) String spec,
+    @Size(max = 100) String model,
+    @Size(max = 100) String serial,
+    @Size(max = 100) String fileGroupId,
+    @Size(max = 500) String note,
+    @Size(max = 10) String status
+) {
+}

--- a/src/main/java/com/cmms11/inventory/InventoryResponse.java
+++ b/src/main/java/com/cmms11/inventory/InventoryResponse.java
@@ -1,0 +1,51 @@
+package com.cmms11.inventory;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: InventoryResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 재고 마스터 응답 페이로드를 표현하는 DTO.
+ */
+public record InventoryResponse(
+    String inventoryId,
+    String name,
+    String assetId,
+    String deptId,
+    String makerName,
+    String spec,
+    String model,
+    String serial,
+    String fileGroupId,
+    String note,
+    String status,
+    String deleteMark,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+    public static InventoryResponse from(Inventory inventory) {
+        String inventoryId = inventory.getId() != null ? inventory.getId().getInventoryId() : null;
+        return new InventoryResponse(
+            inventoryId,
+            inventory.getName(),
+            inventory.getAssetId(),
+            inventory.getDeptId(),
+            inventory.getMakerName(),
+            inventory.getSpec(),
+            inventory.getModel(),
+            inventory.getSerial(),
+            inventory.getFileGroupId(),
+            inventory.getNote(),
+            inventory.getStatus(),
+            inventory.getDeleteMark(),
+            inventory.getCreatedAt(),
+            inventory.getCreatedBy(),
+            inventory.getUpdatedAt(),
+            inventory.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/inventory/InventoryService.java
+++ b/src/main/java/com/cmms11/inventory/InventoryService.java
@@ -1,0 +1,140 @@
+package com.cmms11.inventory;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: InventoryService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 재고 마스터 CRUD 및 조회 로직을 담당하는 서비스.
+ */
+@Service
+@Transactional
+public class InventoryService {
+
+    private static final String MODULE_CODE = "2"; // Inventory master per STRUCTURES.md
+
+    private final InventoryRepository repository;
+    private final AutoNumberService autoNumberService;
+
+    public InventoryService(InventoryRepository repository, AutoNumberService autoNumberService) {
+        this.repository = repository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<InventoryResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Inventory> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, "N", trimmed, pageable);
+        }
+        return page.map(InventoryResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public InventoryResponse get(String inventoryId) {
+        return InventoryResponse.from(getActiveInventory(inventoryId));
+    }
+
+    public InventoryResponse create(InventoryRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+        String requestedId = request.inventoryId();
+
+        Inventory entity;
+        if (requestedId == null || requestedId.isBlank()) {
+            String generatedId = autoNumberService.generateMasterId(companyId, MODULE_CODE);
+            entity = new Inventory();
+            entity.setId(new InventoryId(companyId, generatedId));
+            entity.setCreatedAt(now);
+            entity.setCreatedBy(memberId);
+        } else {
+            String trimmedId = requestedId.trim();
+            InventoryId id = new InventoryId(companyId, trimmedId);
+            Optional<Inventory> existing = repository.findById(id);
+            if (existing.isPresent()) {
+                entity = existing.get();
+                if (!"Y".equalsIgnoreCase(entity.getDeleteMark())) {
+                    throw new IllegalArgumentException("Inventory already exists: " + trimmedId);
+                }
+                if (entity.getCreatedAt() == null) {
+                    entity.setCreatedAt(now);
+                    entity.setCreatedBy(memberId);
+                }
+            } else {
+                entity = new Inventory();
+                entity.setId(id);
+                entity.setCreatedAt(now);
+                entity.setCreatedBy(memberId);
+            }
+        }
+
+        applyRequest(entity, request);
+        entity.setDeleteMark("N");
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+
+        return InventoryResponse.from(repository.save(entity));
+    }
+
+    public InventoryResponse update(String inventoryId, InventoryRequest request) {
+        Inventory entity = getActiveInventory(inventoryId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        return InventoryResponse.from(repository.save(entity));
+    }
+
+    public void delete(String inventoryId) {
+        Inventory entity = getActiveInventory(inventoryId);
+        entity.setDeleteMark("Y");
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        repository.save(entity);
+    }
+
+    private Inventory getActiveInventory(String inventoryId) {
+        InventoryId id = new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, inventoryId);
+        return repository.findById(id)
+            .filter(inventory -> !"Y".equalsIgnoreCase(inventory.getDeleteMark()))
+            .orElseThrow(() -> new NotFoundException("Inventory not found: " + inventoryId));
+    }
+
+    private void applyRequest(Inventory entity, InventoryRequest request) {
+        entity.setName(request.name());
+        entity.setAssetId(request.assetId());
+        entity.setDeptId(request.deptId());
+        entity.setMakerName(request.makerName());
+        entity.setSpec(request.spec());
+        entity.setModel(request.model());
+        entity.setSerial(request.serial());
+        entity.setFileGroupId(request.fileGroupId());
+        entity.setNote(request.note());
+        entity.setStatus(request.status());
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/java/com/cmms11/memo/MemoRepository.java
+++ b/src/main/java/com/cmms11/memo/MemoRepository.java
@@ -1,0 +1,32 @@
+package com.cmms11.memo;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: MemoRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 메모 엔티티의 CRUD 및 검색을 위한 JPA 레포지토리.
+ */
+public interface MemoRepository extends JpaRepository<Memo, MemoId> {
+
+    Page<Memo> findByIdCompanyId(String companyId, Pageable pageable);
+
+    @Query(
+        "select m from Memo m " +
+        "where m.id.companyId = :companyId and (m.id.memoId like :keyword or m.title like :keyword or m.content like :keyword)"
+    )
+    Page<Memo> search(
+        @Param("companyId") String companyId,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<Memo> findByIdCompanyIdAndIdMemoId(String companyId, String memoId);
+}

--- a/src/main/java/com/cmms11/memo/MemoRequest.java
+++ b/src/main/java/com/cmms11/memo/MemoRequest.java
@@ -1,0 +1,21 @@
+package com.cmms11.memo;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 이름: MemoRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 메모 생성/수정 요청 DTO.
+ */
+public record MemoRequest(
+    @Size(max = 10) String memoId,
+    @NotBlank @Size(max = 100) String title,
+    String content,
+    @Size(max = 64) String refEntity,
+    @Size(max = 10) String refId,
+    @Size(max = 100) String fileGroupId
+) {
+}

--- a/src/main/java/com/cmms11/memo/MemoResponse.java
+++ b/src/main/java/com/cmms11/memo/MemoResponse.java
@@ -1,0 +1,39 @@
+package com.cmms11.memo;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이름: MemoResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 메모 응답 DTO.
+ */
+public record MemoResponse(
+    String memoId,
+    String title,
+    String content,
+    String refEntity,
+    String refId,
+    String fileGroupId,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+    public static MemoResponse from(Memo memo) {
+        String memoId = memo.getId() != null ? memo.getId().getMemoId() : null;
+        return new MemoResponse(
+            memoId,
+            memo.getTitle(),
+            memo.getContent(),
+            memo.getRefEntity(),
+            memo.getRefId(),
+            memo.getFileGroupId(),
+            memo.getCreatedAt(),
+            memo.getCreatedBy(),
+            memo.getUpdatedAt(),
+            memo.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/memo/MemoService.java
+++ b/src/main/java/com/cmms11/memo/MemoService.java
@@ -1,0 +1,119 @@
+package com.cmms11.memo;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: MemoService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 메모 CRUD 로직을 제공하는 서비스.
+ */
+@Service
+@Transactional
+public class MemoService {
+
+    private static final String MODULE_CODE = "M";
+
+    private final MemoRepository repository;
+    private final AutoNumberService autoNumberService;
+
+    public MemoService(MemoRepository repository, AutoNumberService autoNumberService) {
+        this.repository = repository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MemoResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<Memo> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyId(companyId, pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, trimmed, pageable);
+        }
+        return page.map(MemoResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public MemoResponse get(String memoId) {
+        return MemoResponse.from(getExisting(memoId));
+    }
+
+    public MemoResponse create(MemoRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        String newId = resolveId(companyId, request.memoId());
+        Memo entity = new Memo();
+        entity.setId(new MemoId(companyId, newId));
+        entity.setCreatedAt(now);
+        entity.setCreatedBy(memberId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+
+        return MemoResponse.from(repository.save(entity));
+    }
+
+    public MemoResponse update(String memoId, MemoRequest request) {
+        Memo entity = getExisting(memoId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        return MemoResponse.from(repository.save(entity));
+    }
+
+    public void delete(String memoId) {
+        Memo entity = getExisting(memoId);
+        repository.delete(entity);
+    }
+
+    private Memo getExisting(String memoId) {
+        return repository
+            .findByIdCompanyIdAndIdMemoId(MemberUserDetailsService.DEFAULT_COMPANY, memoId)
+            .orElseThrow(() -> new NotFoundException("Memo not found: " + memoId));
+    }
+
+    private void applyRequest(Memo entity, MemoRequest request) {
+        entity.setTitle(request.title());
+        entity.setContent(request.content());
+        entity.setRefEntity(request.refEntity());
+        entity.setRefId(request.refId());
+        entity.setFileGroupId(request.fileGroupId());
+    }
+
+    private String resolveId(String companyId, String requestedId) {
+        if (requestedId != null && !requestedId.isBlank()) {
+            String trimmed = requestedId.trim();
+            repository
+                .findByIdCompanyIdAndIdMemoId(companyId, trimmed)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Memo already exists: " + trimmed);
+                });
+            return trimmed;
+        }
+        return autoNumberService.generateTxId(companyId, MODULE_CODE, LocalDate.now());
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/java/com/cmms11/security/CsrfCookieFilter.java
+++ b/src/main/java/com/cmms11/security/CsrfCookieFilter.java
@@ -1,0 +1,45 @@
+package com.cmms11.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * 이름: CsrfCookieFilter
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: Spring Security가 발급한 CSRF 토큰을 읽어 XSRF-TOKEN 쿠키로 동기화하는 필터.
+ */
+public class CsrfCookieFilter extends OncePerRequestFilter {
+
+    private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        if (csrfToken != null) {
+            Cookie existing = WebUtils.getCookie(request, CSRF_COOKIE_NAME);
+            String token = csrfToken.getToken();
+            if (token != null && (existing == null || !token.equals(existing.getValue()))) {
+                Cookie cookie = new Cookie(CSRF_COOKIE_NAME, token);
+                cookie.setPath("/");
+                cookie.setSecure(request.isSecure());
+                cookie.setHttpOnly(false);
+                response.addCookie(cookie);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/cmms11/web/ApprovalController.java
+++ b/src/main/java/com/cmms11/web/ApprovalController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.approval.ApprovalRequest;
+import com.cmms11.approval.ApprovalResponse;
+import com.cmms11.approval.ApprovalService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: ApprovalController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 전자결재 REST API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/approvals")
 public class ApprovalController {
 
-    @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list approvals not implemented"));
+    private final ApprovalService service;
+
+    public ApprovalController(ApprovalService service) {
+        this.service = service;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get approval not implemented"));
+    @GetMapping
+    public Page<ApprovalResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{approvalId}")
+    public ResponseEntity<ApprovalResponse> get(@PathVariable String approvalId) {
+        return ResponseEntity.ok(service.get(approvalId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create approval not implemented"));
+    public ResponseEntity<ApprovalResponse> create(@Valid @RequestBody ApprovalRequest request) {
+        ApprovalResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update approval not implemented"));
+    @PutMapping("/{approvalId}")
+    public ResponseEntity<ApprovalResponse> update(
+        @PathVariable String approvalId,
+        @Valid @RequestBody ApprovalRequest request
+    ) {
+        ApprovalResponse response = service.update(approvalId, request);
+        return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete approval not implemented"));
+    @DeleteMapping("/{approvalId}")
+    public ResponseEntity<Void> delete(@PathVariable String approvalId) {
+        service.delete(approvalId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/CodeController.java
+++ b/src/main/java/com/cmms11/web/CodeController.java
@@ -1,43 +1,112 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.code.CodeItemRequest;
+import com.cmms11.code.CodeItemResponse;
+import com.cmms11.code.CodeService;
+import com.cmms11.code.CodeTypeRequest;
+import com.cmms11.code.CodeTypeResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: CodeController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 공통 코드 타입 및 항목을 관리하는 REST 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/codes")
 public class CodeController {
 
-    @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "type", required = false) String type, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list codes not implemented"));
+    private final CodeService service;
+
+    public CodeController(CodeService service) {
+        this.service = service;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get code not implemented"));
+    @GetMapping("/types")
+    public Page<CodeTypeResponse> listTypes(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.listTypes(q, pageable);
     }
 
-    @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create code not implemented"));
+    @GetMapping("/types/{codeType}")
+    public ResponseEntity<CodeTypeResponse> getType(@PathVariable String codeType) {
+        return ResponseEntity.ok(service.getType(codeType));
     }
 
-    @PutMapping("/{idd}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update code not implemented"));
+    @PostMapping("/types")
+    public ResponseEntity<CodeTypeResponse> createType(@Valid @RequestBody CodeTypeRequest request) {
+        CodeTypeResponse response = service.createType(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete code not implemented"));
+    @PutMapping("/types/{codeType}")
+    public ResponseEntity<CodeTypeResponse> updateType(
+        @PathVariable String codeType,
+        @Valid @RequestBody CodeTypeRequest request
+    ) {
+        CodeTypeResponse response = service.updateType(codeType, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/types/{codeType}")
+    public ResponseEntity<Void> deleteType(@PathVariable String codeType) {
+        service.deleteType(codeType);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/types/{codeType}/items")
+    public Page<CodeItemResponse> listItems(
+        @PathVariable String codeType,
+        @RequestParam(name = "q", required = false) String q,
+        Pageable pageable
+    ) {
+        return service.listItems(codeType, q, pageable);
+    }
+
+    @GetMapping("/types/{codeType}/items/{code}")
+    public ResponseEntity<CodeItemResponse> getItem(@PathVariable String codeType, @PathVariable String code) {
+        return ResponseEntity.ok(service.getItem(codeType, code));
+    }
+
+    @PostMapping("/types/{codeType}/items")
+    public ResponseEntity<CodeItemResponse> createItem(
+        @PathVariable String codeType,
+        @Valid @RequestBody CodeItemRequest request
+    ) {
+        CodeItemRequest payload = new CodeItemRequest(codeType, request.code(), request.name(), request.note());
+        CodeItemResponse response = service.createItem(payload);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/types/{codeType}/items/{code}")
+    public ResponseEntity<CodeItemResponse> updateItem(
+        @PathVariable String codeType,
+        @PathVariable String code,
+        @Valid @RequestBody CodeItemRequest request
+    ) {
+        CodeItemRequest payload = new CodeItemRequest(codeType, code, request.name(), request.note());
+        CodeItemResponse response = service.updateItem(codeType, code, payload);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/types/{codeType}/items/{code}")
+    public ResponseEntity<Void> deleteItem(@PathVariable String codeType, @PathVariable String code) {
+        service.deleteItem(codeType, code);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/cmms11/web/CompanyController.java
+++ b/src/main/java/com/cmms11/web/CompanyController.java
@@ -1,43 +1,69 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.domain.company.CompanyRequest;
+import com.cmms11.domain.company.CompanyResponse;
+import com.cmms11.domain.company.CompanyService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: CompanyController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 기준정보 API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/domain/companies")
 public class CompanyController {
 
-    @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list companies not implemented"));
+    private final CompanyService service;
+
+    public CompanyController(CompanyService service) {
+        this.service = service;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get company not implemented"));
+    @GetMapping
+    public Page<CompanyResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{companyId}")
+    public ResponseEntity<CompanyResponse> get(@PathVariable String companyId) {
+        return ResponseEntity.ok(service.get(companyId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create company not implemented"));
+    public ResponseEntity<CompanyResponse> create(@Valid @RequestBody CompanyRequest request) {
+        CompanyResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update company not implemented"));
+    @PutMapping("/{companyId}")
+    public ResponseEntity<CompanyResponse> update(
+        @PathVariable String companyId,
+        @Valid @RequestBody CompanyRequest request
+    ) {
+        CompanyResponse response = service.update(companyId, request);
+        return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete company not implemented"));
+    @DeleteMapping("/{companyId}")
+    public ResponseEntity<Void> delete(@PathVariable String companyId) {
+        service.delete(companyId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/cmms11/web/DeptController.java
+++ b/src/main/java/com/cmms11/web/DeptController.java
@@ -1,43 +1,69 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.domain.dept.DeptRequest;
+import com.cmms11.domain.dept.DeptResponse;
+import com.cmms11.domain.dept.DeptService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: DeptController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 부서 기준정보 API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/domain/depts")
 public class DeptController {
 
+    private final DeptService service;
+
+    public DeptController(DeptService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list depts not implemented"));
+    public Page<DeptResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{deptId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get dept not implemented"));
+    public ResponseEntity<DeptResponse> get(@PathVariable String deptId) {
+        return ResponseEntity.ok(service.get(deptId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create dept not implemented"));
+    public ResponseEntity<DeptResponse> create(@Valid @RequestBody DeptRequest request) {
+        DeptResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{deptId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update dept not implemented"));
+    public ResponseEntity<DeptResponse> update(
+        @PathVariable String deptId,
+        @Valid @RequestBody DeptRequest request
+    ) {
+        DeptResponse response = service.update(deptId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{deptId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete dept not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String deptId) {
+        service.delete(deptId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/cmms11/web/FuncController.java
+++ b/src/main/java/com/cmms11/web/FuncController.java
@@ -1,0 +1,69 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.func.FuncRequest;
+import com.cmms11.domain.func.FuncResponse;
+import com.cmms11.domain.func.FuncService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 이름: FuncController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 기능위치 기준정보 API 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/domain/funcs")
+public class FuncController {
+
+    private final FuncService service;
+
+    public FuncController(FuncService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<FuncResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{funcId}")
+    public ResponseEntity<FuncResponse> get(@PathVariable String funcId) {
+        return ResponseEntity.ok(service.get(funcId));
+    }
+
+    @PostMapping
+    public ResponseEntity<FuncResponse> create(@Valid @RequestBody FuncRequest request) {
+        FuncResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{funcId}")
+    public ResponseEntity<FuncResponse> update(
+        @PathVariable String funcId,
+        @Valid @RequestBody FuncRequest request
+    ) {
+        FuncResponse response = service.update(funcId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{funcId}")
+    public ResponseEntity<Void> delete(@PathVariable String funcId) {
+        service.delete(funcId);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/cmms11/web/InspectionController.java
+++ b/src/main/java/com/cmms11/web/InspectionController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.inspection.InspectionRequest;
+import com.cmms11.inspection.InspectionResponse;
+import com.cmms11.inspection.InspectionService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: InspectionController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 예방점검 REST API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/inspections")
 public class InspectionController {
 
+    private final InspectionService service;
+
+    public InspectionController(InspectionService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list inspections not implemented"));
+    public Page<InspectionResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{inspectionId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get inspection not implemented"));
+    public ResponseEntity<InspectionResponse> get(@PathVariable String inspectionId) {
+        return ResponseEntity.ok(service.get(inspectionId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create inspection not implemented"));
+    public ResponseEntity<InspectionResponse> create(@Valid @RequestBody InspectionRequest request) {
+        InspectionResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{inspectionId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update inspection not implemented"));
+    public ResponseEntity<InspectionResponse> update(
+        @PathVariable String inspectionId,
+        @Valid @RequestBody InspectionRequest request
+    ) {
+        InspectionResponse response = service.update(inspectionId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{inspectionId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete inspection not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String inspectionId) {
+        service.delete(inspectionId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/InventoryController.java
+++ b/src/main/java/com/cmms11/web/InventoryController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.inventory.InventoryRequest;
+import com.cmms11.inventory.InventoryResponse;
+import com.cmms11.inventory.InventoryService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: InventoryController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 재고 마스터 CRUD REST 엔드포인트를 제공하는 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/inventories")
 public class InventoryController {
 
+    private final InventoryService service;
+
+    public InventoryController(InventoryService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list inventories not implemented"));
+    public Page<InventoryResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{inventoryId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get inventory not implemented"));
+    public ResponseEntity<InventoryResponse> get(@PathVariable String inventoryId) {
+        return ResponseEntity.ok(service.get(inventoryId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create inventory not implemented"));
+    public ResponseEntity<InventoryResponse> create(@Valid @RequestBody InventoryRequest request) {
+        InventoryResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{inventoryId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update inventory not implemented"));
+    public ResponseEntity<InventoryResponse> update(
+        @PathVariable String inventoryId,
+        @Valid @RequestBody InventoryRequest request
+    ) {
+        InventoryResponse response = service.update(inventoryId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{inventoryId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete inventory not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String inventoryId) {
+        service.delete(inventoryId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/MemoController.java
+++ b/src/main/java/com/cmms11/web/MemoController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.memo.MemoRequest;
+import com.cmms11.memo.MemoResponse;
+import com.cmms11.memo.MemoService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: MemoController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 메모 REST API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/memos")
 public class MemoController {
 
+    private final MemoService service;
+
+    public MemoController(MemoService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list memos not implemented"));
+    public Page<MemoResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{memoId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get memo not implemented"));
+    public ResponseEntity<MemoResponse> get(@PathVariable String memoId) {
+        return ResponseEntity.ok(service.get(memoId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create memo not implemented"));
+    public ResponseEntity<MemoResponse> create(@Valid @RequestBody MemoRequest request) {
+        MemoResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{memoId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update memo not implemented"));
+    public ResponseEntity<MemoResponse> update(
+        @PathVariable String memoId,
+        @Valid @RequestBody MemoRequest request
+    ) {
+        MemoResponse response = service.update(memoId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{memoId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete memo not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String memoId) {
+        service.delete(memoId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/SiteController.java
+++ b/src/main/java/com/cmms11/web/SiteController.java
@@ -1,43 +1,69 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.domain.site.SiteRequest;
+import com.cmms11.domain.site.SiteResponse;
+import com.cmms11.domain.site.SiteService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: SiteController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 사업장 기준정보 API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/domain/sites")
 public class SiteController {
 
+    private final SiteService service;
+
+    public SiteController(SiteService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list sites not implemented"));
+    public Page<SiteResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{siteId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get site not implemented"));
+    public ResponseEntity<SiteResponse> get(@PathVariable String siteId) {
+        return ResponseEntity.ok(service.get(siteId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create site not implemented"));
+    public ResponseEntity<SiteResponse> create(@Valid @RequestBody SiteRequest request) {
+        SiteResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{siteId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update site not implemented"));
+    public ResponseEntity<SiteResponse> update(
+        @PathVariable String siteId,
+        @Valid @RequestBody SiteRequest request
+    ) {
+        SiteResponse response = service.update(siteId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{siteId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete site not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String siteId) {
+        service.delete(siteId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/cmms11/web/StorageController.java
+++ b/src/main/java/com/cmms11/web/StorageController.java
@@ -1,0 +1,69 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.storage.StorageRequest;
+import com.cmms11.domain.storage.StorageResponse;
+import com.cmms11.domain.storage.StorageService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 이름: StorageController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 창고(Storage) 기준정보 API 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/domain/storages")
+public class StorageController {
+
+    private final StorageService service;
+
+    public StorageController(StorageService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<StorageResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{storageId}")
+    public ResponseEntity<StorageResponse> get(@PathVariable String storageId) {
+        return ResponseEntity.ok(service.get(storageId));
+    }
+
+    @PostMapping
+    public ResponseEntity<StorageResponse> create(@Valid @RequestBody StorageRequest request) {
+        StorageResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{storageId}")
+    public ResponseEntity<StorageResponse> update(
+        @PathVariable String storageId,
+        @Valid @RequestBody StorageRequest request
+    ) {
+        StorageResponse response = service.update(storageId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{storageId}")
+    public ResponseEntity<Void> delete(@PathVariable String storageId) {
+        service.delete(storageId);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/cmms11/web/WorkOrderController.java
+++ b/src/main/java/com/cmms11/web/WorkOrderController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.workorder.WorkOrderRequest;
+import com.cmms11.workorder.WorkOrderResponse;
+import com.cmms11.workorder.WorkOrderService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: WorkOrderController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업지시 REST API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/workorders")
 public class WorkOrderController {
 
+    private final WorkOrderService service;
+
+    public WorkOrderController(WorkOrderService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list workorders not implemented"));
+    public Page<WorkOrderResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{workOrderId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get workorder not implemented"));
+    public ResponseEntity<WorkOrderResponse> get(@PathVariable String workOrderId) {
+        return ResponseEntity.ok(service.get(workOrderId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create workorder not implemented"));
+    public ResponseEntity<WorkOrderResponse> create(@Valid @RequestBody WorkOrderRequest request) {
+        WorkOrderResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{workOrderId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update workorder not implemented"));
+    public ResponseEntity<WorkOrderResponse> update(
+        @PathVariable String workOrderId,
+        @Valid @RequestBody WorkOrderRequest request
+    ) {
+        WorkOrderResponse response = service.update(workOrderId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{workOrderId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete workorder not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String workOrderId) {
+        service.delete(workOrderId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/WorkPermitController.java
+++ b/src/main/java/com/cmms11/web/WorkPermitController.java
@@ -1,43 +1,68 @@
 package com.cmms11.web;
 
-import java.util.Map;
+import com.cmms11.workpermit.WorkPermitRequest;
+import com.cmms11.workpermit.WorkPermitResponse;
+import com.cmms11.workpermit.WorkPermitService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 이름: WorkPermitController
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업허가 REST API 컨트롤러.
+ */
 @RestController
 @RequestMapping("/api/workpermits")
 public class WorkPermitController {
 
+    private final WorkPermitService service;
+
+    public WorkPermitController(WorkPermitService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "list workpermits not implemented"));
+    public Page<WorkPermitResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
     }
 
     @GetMapping("/{workPermitId}")
-    public ResponseEntity<?> get(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "get workpermit not implemented"));
+    public ResponseEntity<WorkPermitResponse> get(@PathVariable String workPermitId) {
+        return ResponseEntity.ok(service.get(workPermitId));
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "create workpermit not implemented"));
+    public ResponseEntity<WorkPermitResponse> create(@Valid @RequestBody WorkPermitRequest request) {
+        WorkPermitResponse response = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{workPermitId}")
-    public ResponseEntity<?> update(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "update workpermit not implemented"));
+    public ResponseEntity<WorkPermitResponse> update(
+        @PathVariable String workPermitId,
+        @Valid @RequestBody WorkPermitRequest request
+    ) {
+        WorkPermitResponse response = service.update(workPermitId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{workPermitId}")
-    public ResponseEntity<?> delete(@PathVariable String id) {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(Map.of("message", "delete workpermit not implemented"));
+    public ResponseEntity<Void> delete(@PathVariable String workPermitId) {
+        service.delete(workPermitId);
+        return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/workorder/WorkOrderRepository.java
+++ b/src/main/java/com/cmms11/workorder/WorkOrderRepository.java
@@ -1,0 +1,32 @@
+package com.cmms11.workorder;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: WorkOrderRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업지시 엔티티에 대한 CRUD 및 검색 JPA 레포지토리.
+ */
+public interface WorkOrderRepository extends JpaRepository<WorkOrder, WorkOrderId> {
+
+    Page<WorkOrder> findByIdCompanyId(String companyId, Pageable pageable);
+
+    @Query(
+        "select w from WorkOrder w " +
+        "where w.id.companyId = :companyId and (w.id.workOrderId like :keyword or w.name like :keyword)"
+    )
+    Page<WorkOrder> search(
+        @Param("companyId") String companyId,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<WorkOrder> findByIdCompanyIdAndIdWorkOrderId(String companyId, String workOrderId);
+}

--- a/src/main/java/com/cmms11/workorder/WorkOrderRequest.java
+++ b/src/main/java/com/cmms11/workorder/WorkOrderRequest.java
@@ -1,0 +1,33 @@
+package com.cmms11.workorder;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 이름: WorkOrderRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업지시 생성/수정 요청 DTO.
+ */
+public record WorkOrderRequest(
+    @Size(max = 10) String workOrderId,
+    @NotBlank @Size(max = 100) String name,
+    @NotBlank @Size(max = 10) String plantId,
+    @NotBlank @Size(max = 5) String jobId,
+    @NotBlank @Size(max = 5) String siteId,
+    @NotBlank @Size(max = 5) String deptId,
+    @Size(max = 5) String memberId,
+    LocalDate plannedDate,
+    BigDecimal plannedCost,
+    BigDecimal plannedLabor,
+    LocalDate actualDate,
+    BigDecimal actualCost,
+    BigDecimal actualLabor,
+    @Size(max = 10) String status,
+    @Size(max = 100) String fileGroupId,
+    @Size(max = 500) String note
+) {
+}

--- a/src/main/java/com/cmms11/workorder/WorkOrderResponse.java
+++ b/src/main/java/com/cmms11/workorder/WorkOrderResponse.java
@@ -1,0 +1,61 @@
+package com.cmms11.workorder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 이름: WorkOrderResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업지시 응답 DTO.
+ */
+public record WorkOrderResponse(
+    String workOrderId,
+    String name,
+    String plantId,
+    String jobId,
+    String siteId,
+    String deptId,
+    String memberId,
+    LocalDate plannedDate,
+    BigDecimal plannedCost,
+    BigDecimal plannedLabor,
+    LocalDate actualDate,
+    BigDecimal actualCost,
+    BigDecimal actualLabor,
+    String status,
+    String fileGroupId,
+    String note,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+    public static WorkOrderResponse from(WorkOrder workOrder) {
+        String workOrderId = workOrder.getId() != null ? workOrder.getId().getWorkOrderId() : null;
+        return new WorkOrderResponse(
+            workOrderId,
+            workOrder.getName(),
+            workOrder.getPlantId(),
+            workOrder.getJobId(),
+            workOrder.getSiteId(),
+            workOrder.getDeptId(),
+            workOrder.getMemberId(),
+            workOrder.getPlannedDate(),
+            workOrder.getPlannedCost(),
+            workOrder.getPlannedLabor(),
+            workOrder.getActualDate(),
+            workOrder.getActualCost(),
+            workOrder.getActualLabor(),
+            workOrder.getStatus(),
+            workOrder.getFileGroupId(),
+            workOrder.getNote(),
+            workOrder.getCreatedAt(),
+            workOrder.getCreatedBy(),
+            workOrder.getUpdatedAt(),
+            workOrder.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/workorder/WorkOrderService.java
+++ b/src/main/java/com/cmms11/workorder/WorkOrderService.java
@@ -1,0 +1,130 @@
+package com.cmms11.workorder;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: WorkOrderService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업지시 트랜잭션 CRUD 로직을 제공하는 서비스.
+ */
+@Service
+@Transactional
+public class WorkOrderService {
+
+    private static final String MODULE_CODE = "O";
+
+    private final WorkOrderRepository repository;
+    private final AutoNumberService autoNumberService;
+
+    public WorkOrderService(WorkOrderRepository repository, AutoNumberService autoNumberService) {
+        this.repository = repository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<WorkOrderResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<WorkOrder> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyId(companyId, pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, trimmed, pageable);
+        }
+        return page.map(WorkOrderResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public WorkOrderResponse get(String workOrderId) {
+        return WorkOrderResponse.from(getExisting(workOrderId));
+    }
+
+    public WorkOrderResponse create(WorkOrderRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        String newId = resolveId(companyId, request.workOrderId(), request.plannedDate());
+        WorkOrder entity = new WorkOrder();
+        entity.setId(new WorkOrderId(companyId, newId));
+        entity.setCreatedAt(now);
+        entity.setCreatedBy(memberId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+
+        return WorkOrderResponse.from(repository.save(entity));
+    }
+
+    public WorkOrderResponse update(String workOrderId, WorkOrderRequest request) {
+        WorkOrder entity = getExisting(workOrderId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        return WorkOrderResponse.from(repository.save(entity));
+    }
+
+    public void delete(String workOrderId) {
+        WorkOrder entity = getExisting(workOrderId);
+        repository.delete(entity);
+    }
+
+    private WorkOrder getExisting(String workOrderId) {
+        return repository
+            .findByIdCompanyIdAndIdWorkOrderId(MemberUserDetailsService.DEFAULT_COMPANY, workOrderId)
+            .orElseThrow(() -> new NotFoundException("WorkOrder not found: " + workOrderId));
+    }
+
+    private void applyRequest(WorkOrder entity, WorkOrderRequest request) {
+        entity.setName(request.name());
+        entity.setPlantId(request.plantId());
+        entity.setJobId(request.jobId());
+        entity.setSiteId(request.siteId());
+        entity.setDeptId(request.deptId());
+        entity.setMemberId(request.memberId());
+        entity.setPlannedDate(request.plannedDate());
+        entity.setPlannedCost(request.plannedCost());
+        entity.setPlannedLabor(request.plannedLabor());
+        entity.setActualDate(request.actualDate());
+        entity.setActualCost(request.actualCost());
+        entity.setActualLabor(request.actualLabor());
+        entity.setStatus(request.status());
+        entity.setFileGroupId(request.fileGroupId());
+        entity.setNote(request.note());
+    }
+
+    private String resolveId(String companyId, String requestedId, LocalDate referenceDate) {
+        if (requestedId != null && !requestedId.isBlank()) {
+            String trimmed = requestedId.trim();
+            repository
+                .findByIdCompanyIdAndIdWorkOrderId(companyId, trimmed)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("WorkOrder already exists: " + trimmed);
+                });
+            return trimmed;
+        }
+        LocalDate date = referenceDate != null ? referenceDate : LocalDate.now();
+        return autoNumberService.generateTxId(companyId, MODULE_CODE, date);
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/java/com/cmms11/workpermit/WorkPermitRepository.java
+++ b/src/main/java/com/cmms11/workpermit/WorkPermitRepository.java
@@ -1,0 +1,32 @@
+package com.cmms11.workpermit;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 이름: WorkPermitRepository
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업허가 엔티티에 대한 CRUD 및 검색 JPA 레포지토리.
+ */
+public interface WorkPermitRepository extends JpaRepository<WorkPermit, WorkPermitId> {
+
+    Page<WorkPermit> findByIdCompanyId(String companyId, Pageable pageable);
+
+    @Query(
+        "select w from WorkPermit w " +
+        "where w.id.companyId = :companyId and (w.id.workPermitId like :keyword or w.name like :keyword)"
+    )
+    Page<WorkPermit> search(
+        @Param("companyId") String companyId,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
+
+    Optional<WorkPermit> findByIdCompanyIdAndIdWorkPermitId(String companyId, String workPermitId);
+}

--- a/src/main/java/com/cmms11/workpermit/WorkPermitRequest.java
+++ b/src/main/java/com/cmms11/workpermit/WorkPermitRequest.java
@@ -1,0 +1,32 @@
+package com.cmms11.workpermit;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+/**
+ * 이름: WorkPermitRequest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업허가 생성/수정 요청 DTO.
+ */
+public record WorkPermitRequest(
+    @Size(max = 10) String workPermitId,
+    @NotBlank @Size(max = 100) String name,
+    @NotBlank @Size(max = 10) String plantId,
+    @NotBlank @Size(max = 5) String jobId,
+    @NotBlank @Size(max = 5) String siteId,
+    @NotBlank @Size(max = 5) String deptId,
+    @Size(max = 5) String memberId,
+    LocalDate plannedDate,
+    LocalDate actualDate,
+    @Size(max = 500) String workSummary,
+    @Size(max = 500) String hazardFactor,
+    @Size(max = 500) String safetyFactor,
+    String checksheetJson,
+    @Size(max = 10) String status,
+    @Size(max = 100) String fileGroupId,
+    @Size(max = 500) String note
+) {
+}

--- a/src/main/java/com/cmms11/workpermit/WorkPermitResponse.java
+++ b/src/main/java/com/cmms11/workpermit/WorkPermitResponse.java
@@ -1,0 +1,60 @@
+package com.cmms11.workpermit;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 이름: WorkPermitResponse
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업허가 응답 DTO.
+ */
+public record WorkPermitResponse(
+    String workPermitId,
+    String name,
+    String plantId,
+    String jobId,
+    String siteId,
+    String deptId,
+    String memberId,
+    LocalDate plannedDate,
+    LocalDate actualDate,
+    String workSummary,
+    String hazardFactor,
+    String safetyFactor,
+    String checksheetJson,
+    String status,
+    String fileGroupId,
+    String note,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+    public static WorkPermitResponse from(WorkPermit workPermit) {
+        String workPermitId = workPermit.getId() != null ? workPermit.getId().getWorkPermitId() : null;
+        return new WorkPermitResponse(
+            workPermitId,
+            workPermit.getName(),
+            workPermit.getPlantId(),
+            workPermit.getJobId(),
+            workPermit.getSiteId(),
+            workPermit.getDeptId(),
+            workPermit.getMemberId(),
+            workPermit.getPlannedDate(),
+            workPermit.getActualDate(),
+            workPermit.getWorkSummary(),
+            workPermit.getHazardFactor(),
+            workPermit.getSafetyFactor(),
+            workPermit.getChecksheetJson(),
+            workPermit.getStatus(),
+            workPermit.getFileGroupId(),
+            workPermit.getNote(),
+            workPermit.getCreatedAt(),
+            workPermit.getCreatedBy(),
+            workPermit.getUpdatedAt(),
+            workPermit.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/workpermit/WorkPermitService.java
+++ b/src/main/java/com/cmms11/workpermit/WorkPermitService.java
@@ -1,0 +1,130 @@
+package com.cmms11.workpermit;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이름: WorkPermitService
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 작업허가 트랜잭션 CRUD 로직을 처리하는 서비스.
+ */
+@Service
+@Transactional
+public class WorkPermitService {
+
+    private static final String MODULE_CODE = "P";
+
+    private final WorkPermitRepository repository;
+    private final AutoNumberService autoNumberService;
+
+    public WorkPermitService(WorkPermitRepository repository, AutoNumberService autoNumberService) {
+        this.repository = repository;
+        this.autoNumberService = autoNumberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<WorkPermitResponse> list(String keyword, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        Page<WorkPermit> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = repository.findByIdCompanyId(companyId, pageable);
+        } else {
+            String trimmed = "%" + keyword.trim() + "%";
+            page = repository.search(companyId, trimmed, pageable);
+        }
+        return page.map(WorkPermitResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public WorkPermitResponse get(String workPermitId) {
+        return WorkPermitResponse.from(getExisting(workPermitId));
+    }
+
+    public WorkPermitResponse create(WorkPermitRequest request) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        LocalDateTime now = LocalDateTime.now();
+        String memberId = currentMemberId();
+
+        String newId = resolveId(companyId, request.workPermitId(), request.plannedDate());
+        WorkPermit entity = new WorkPermit();
+        entity.setId(new WorkPermitId(companyId, newId));
+        entity.setCreatedAt(now);
+        entity.setCreatedBy(memberId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(now);
+        entity.setUpdatedBy(memberId);
+
+        return WorkPermitResponse.from(repository.save(entity));
+    }
+
+    public WorkPermitResponse update(String workPermitId, WorkPermitRequest request) {
+        WorkPermit entity = getExisting(workPermitId);
+        applyRequest(entity, request);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setUpdatedBy(currentMemberId());
+        return WorkPermitResponse.from(repository.save(entity));
+    }
+
+    public void delete(String workPermitId) {
+        WorkPermit entity = getExisting(workPermitId);
+        repository.delete(entity);
+    }
+
+    private WorkPermit getExisting(String workPermitId) {
+        return repository
+            .findByIdCompanyIdAndIdWorkPermitId(MemberUserDetailsService.DEFAULT_COMPANY, workPermitId)
+            .orElseThrow(() -> new NotFoundException("WorkPermit not found: " + workPermitId));
+    }
+
+    private void applyRequest(WorkPermit entity, WorkPermitRequest request) {
+        entity.setName(request.name());
+        entity.setPlantId(request.plantId());
+        entity.setJobId(request.jobId());
+        entity.setSiteId(request.siteId());
+        entity.setDeptId(request.deptId());
+        entity.setMemberId(request.memberId());
+        entity.setPlannedDate(request.plannedDate());
+        entity.setActualDate(request.actualDate());
+        entity.setWorkSummary(request.workSummary());
+        entity.setHazardFactor(request.hazardFactor());
+        entity.setSafetyFactor(request.safetyFactor());
+        entity.setChecksheetJson(request.checksheetJson());
+        entity.setStatus(request.status());
+        entity.setFileGroupId(request.fileGroupId());
+        entity.setNote(request.note());
+    }
+
+    private String resolveId(String companyId, String requestedId, LocalDate referenceDate) {
+        if (requestedId != null && !requestedId.isBlank()) {
+            String trimmed = requestedId.trim();
+            repository
+                .findByIdCompanyIdAndIdWorkPermitId(companyId, trimmed)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("WorkPermit already exists: " + trimmed);
+                });
+            return trimmed;
+        }
+        LocalDate date = referenceDate != null ? referenceDate : LocalDate.now();
+        return autoNumberService.generateTxId(companyId, MODULE_CODE, date);
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
+    }
+}

--- a/src/main/resources/templates/domain/func/form.html
+++ b/src/main/resources/templates/domain/func/form.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>기능위치 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <a href="list.html">기능위치</a>
+          <span class="sep">/</span>
+          <span>등록/수정</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">기능위치 등록/수정</div>
+              <div class="toolbar">
+                <a class="btn" href="list.html">목록</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <form data-validate>
+                <div class="section">
+                  <div class="section-title">기본정보</div>
+                  <div class="grid cols-12">
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="func_id">기능위치 코드</label>
+                      <input id="func_id" name="func_id" class="input" required maxlength="5" placeholder="예: F0001" />
+                    </div>
+                    <div class="form-row col-span-8">
+                      <label class="label required" for="name">기능위치 명</label>
+                      <input id="name" name="name" class="input" required maxlength="100" />
+                    </div>
+                  </div>
+                  <div class="form-row col-span-12">
+                    <label class="label" for="note">비고</label>
+                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                  </div>
+                </div>
+
+                <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
+                  <button class="btn" type="reset">초기화</button>
+                  <button class="btn primary" type="submit">저장</button>
+                </div>
+              </form>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>
+

--- a/src/main/resources/templates/domain/func/list.html
+++ b/src/main/resources/templates/domain/func/list.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>기능위치 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>기능위치</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">기능위치 목록</div>
+              <div class="toolbar">
+                <a class="btn" href="#">정보보기</a>
+                <a class="btn primary" href="form.html">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="section">
+                <div class="section-title">필터</div>
+                <div class="grid cols-12">
+                  <div class="col-span-3">
+                    <input class="input" placeholder="기능위치 코드" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="기능위치 명" />
+                  </div>
+                  <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
+                    <button class="btn">초기화</button>
+                    <button class="btn">검색</button>
+                  </div>
+                </div>
+              </div>
+
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width:140px">기능위치 코드</th>
+                    <th>기능위치 명</th>
+                    <th style="width:200px">비고</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-row-link="form.html">
+                    <td><a href="form.html">F001</a></td>
+                    <td>펌프 라인</td>
+                    <td>예시 데이터</td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="row" style="margin-top:12px">
+                <div class="spacer"></div>
+                <div class="pagination">
+                  <button class="btn sm" disabled>이전</button>
+                  <button class="btn sm">다음</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>
+

--- a/src/main/resources/templates/domain/storage/form.html
+++ b/src/main/resources/templates/domain/storage/form.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>창고 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <a href="list.html">창고</a>
+          <span class="sep">/</span>
+          <span>등록/수정</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">창고 등록/수정</div>
+              <div class="toolbar">
+                <a class="btn" href="list.html">목록</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <form data-validate>
+                <div class="section">
+                  <div class="section-title">기본정보</div>
+                  <div class="grid cols-12">
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="storage_id">창고 코드</label>
+                      <input id="storage_id" name="storage_id" class="input" required maxlength="5" placeholder="예: ST001" />
+                    </div>
+                    <div class="form-row col-span-8">
+                      <label class="label required" for="name">창고 명</label>
+                      <input id="name" name="name" class="input" required maxlength="100" />
+                    </div>
+                  </div>
+                  <div class="form-row col-span-12">
+                    <label class="label" for="note">비고</label>
+                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                  </div>
+                </div>
+
+                <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
+                  <button class="btn" type="reset">초기화</button>
+                  <button class="btn primary" type="submit">저장</button>
+                </div>
+              </form>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>
+

--- a/src/main/resources/templates/domain/storage/list.html
+++ b/src/main/resources/templates/domain/storage/list.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>창고 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>창고</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">창고 목록</div>
+              <div class="toolbar">
+                <a class="btn" href="#">정보보기</a>
+                <a class="btn primary" href="form.html">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="section">
+                <div class="section-title">필터</div>
+                <div class="grid cols-12">
+                  <div class="col-span-3">
+                    <input class="input" placeholder="창고 코드" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="창고 명" />
+                  </div>
+                  <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
+                    <button class="btn">초기화</button>
+                    <button class="btn">검색</button>
+                  </div>
+                </div>
+              </div>
+
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width:140px">창고 코드</th>
+                    <th>창고 명</th>
+                    <th style="width:200px">비고</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-row-link="form.html">
+                    <td><a href="form.html">ST001</a></td>
+                    <td>중앙 창고</td>
+                    <td>예시 데이터</td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="row" style="margin-top:12px">
+                <div class="spacer"></div>
+                <div class="pagination">
+                  <button class="btn sm" disabled>이전</button>
+                  <button class="btn sm">다음</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>
+

--- a/src/test/java/com/cmms11/domain/company/CompanyServiceTest.java
+++ b/src/test/java/com/cmms11/domain/company/CompanyServiceTest.java
@@ -1,0 +1,152 @@
+package com.cmms11.domain.company;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.cmms11.common.error.NotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * 이름: CompanyServiceTest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: CompanyService의 주요 CRUD 동작을 검증하는 단위 테스트.
+ */
+@DataJpaTest
+@Import(CompanyService.class)
+class CompanyServiceTest {
+
+    @Autowired
+    private CompanyService service;
+
+    @Autowired
+    private CompanyRepository repository;
+
+    @BeforeEach
+    void setUpAuthentication() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                "tester",
+                "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            )
+        );
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createNewCompany_insertsRecordWithAuditFields() {
+        CompanyRequest request = new CompanyRequest("C9000", "Test Company", "memo");
+
+        CompanyResponse response = service.create(request);
+
+        assertThat(response.companyId()).isEqualTo("C9000");
+        assertThat(response.deleteMark()).isEqualTo("N");
+        assertThat(response.createdBy()).isEqualTo("tester");
+
+        Company saved = repository.findById("C9000").orElseThrow();
+        assertThat(saved.getName()).isEqualTo("Test Company");
+        assertThat(saved.getDeleteMark()).isEqualTo("N");
+    }
+
+    @Test
+    void createReactivatesSoftDeletedCompany() {
+        Company existing = new Company();
+        existing.setCompanyId("C8000");
+        existing.setName("Legacy");
+        existing.setDeleteMark("Y");
+        repository.save(existing);
+
+        CompanyResponse response = service.create(new CompanyRequest("C8000", "Reactivated", "note"));
+
+        assertThat(response.companyId()).isEqualTo("C8000");
+        assertThat(response.deleteMark()).isEqualTo("N");
+        assertThat(repository.findById("C8000").orElseThrow().getDeleteMark()).isEqualTo("N");
+    }
+
+    @Test
+    void createThrowsWhenCompanyAlreadyExists() {
+        Company existing = new Company();
+        existing.setCompanyId("C7000");
+        existing.setName("Active");
+        existing.setDeleteMark("N");
+        repository.save(existing);
+
+        assertThatThrownBy(() -> service.create(new CompanyRequest("C7000", "Another", null)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("C7000");
+    }
+
+    @Test
+    void updateModifiesExistingCompany() {
+        Company existing = new Company();
+        existing.setCompanyId("C6000");
+        existing.setName("Before");
+        existing.setDeleteMark("N");
+        repository.save(existing);
+
+        CompanyResponse response = service.update("C6000", new CompanyRequest("C6000", "After", "memo"));
+
+        assertThat(response.name()).isEqualTo("After");
+        assertThat(repository.findById("C6000").orElseThrow().getName()).isEqualTo("After");
+    }
+
+    @Test
+    void deleteMarksCompanyAsDeleted() {
+        Company existing = new Company();
+        existing.setCompanyId("C5000");
+        existing.setName("ToRemove");
+        existing.setDeleteMark("N");
+        repository.save(existing);
+
+        service.delete("C5000");
+
+        assertThat(repository.findById("C5000").orElseThrow().getDeleteMark()).isEqualTo("Y");
+    }
+
+    @Test
+    void getThrowsNotFoundForMissingCompany() {
+        assertThatThrownBy(() -> service.get("XXXX"))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void listReturnsOnlyActiveCompaniesMatchingKeyword() {
+        Company alpha = new Company();
+        alpha.setCompanyId("C1000");
+        alpha.setName("Alpha Plant");
+        repository.save(alpha);
+
+        Company beta = new Company();
+        beta.setCompanyId("C1001");
+        beta.setName("Beta Plant");
+        repository.save(beta);
+
+        Company deleted = new Company();
+        deleted.setCompanyId("C1002");
+        deleted.setName("Alpha Archived");
+        deleted.setDeleteMark("Y");
+        repository.save(deleted);
+
+        Page<CompanyResponse> result = service.list("Alpha", PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).companyId()).isEqualTo("C1000");
+    }
+}

--- a/src/test/java/com/cmms11/inventory/InventoryServiceTest.java
+++ b/src/test/java/com/cmms11/inventory/InventoryServiceTest.java
@@ -1,0 +1,271 @@
+package com.cmms11.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * 이름: InventoryServiceTest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: InventoryService의 CRUD 동작을 검증하는 단위 테스트.
+ */
+@DataJpaTest
+@Import({InventoryService.class, AutoNumberService.class})
+class InventoryServiceTest {
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @BeforeEach
+    void setUpAuthentication() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                "tester",
+                "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            )
+        );
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createWithoutIdGeneratesNewInventoryNumber() {
+        InventoryRequest request = new InventoryRequest(
+            null,
+            "베어링",
+            "ASSET",
+            "D0001",
+            "SKF",
+            "6205ZZ",
+            "MODEL-01",
+            "SN-001",
+            "FG0001",
+            "예비 부품",
+            "ACTIVE"
+        );
+
+        InventoryResponse response = inventoryService.create(request);
+
+        assertThat(response.inventoryId()).startsWith("2");
+        assertThat(response.inventoryId()).hasSize(10);
+        assertThat(response.deleteMark()).isEqualTo("N");
+        assertThat(response.createdBy()).isEqualTo("tester");
+
+        Inventory saved = inventoryRepository
+            .findById(new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, response.inventoryId()))
+            .orElseThrow();
+        assertThat(saved.getName()).isEqualTo("베어링");
+        assertThat(saved.getDeleteMark()).isEqualTo("N");
+    }
+
+    @Test
+    void createReactivatesSoftDeletedInventory() {
+        Inventory existing = new Inventory();
+        existing.setId(new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, "2000000001"));
+        existing.setName("사용중지 품목");
+        existing.setDeleteMark("Y");
+        inventoryRepository.save(existing);
+
+        InventoryRequest request = new InventoryRequest(
+            "2000000001",
+            "재사용 품목",
+            "ASSET",
+            "D0002",
+            null,
+            null,
+            null,
+            null,
+            null,
+            "재활성화",
+            "ACTIVE"
+        );
+
+        InventoryResponse response = inventoryService.create(request);
+
+        assertThat(response.inventoryId()).isEqualTo("2000000001");
+        assertThat(response.deleteMark()).isEqualTo("N");
+
+        Inventory saved = inventoryRepository
+            .findById(new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, "2000000001"))
+            .orElseThrow();
+        assertThat(saved.getDeleteMark()).isEqualTo("N");
+        assertThat(saved.getDeptId()).isEqualTo("D0002");
+    }
+
+    @Test
+    void createThrowsWhenInventoryAlreadyExists() {
+        Inventory existing = new Inventory();
+        existing.setId(new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, "2000000002"));
+        existing.setName("활성 품목");
+        existing.setDeleteMark("N");
+        inventoryRepository.save(existing);
+
+        InventoryRequest request = new InventoryRequest(
+            "2000000002",
+            "중복 품목",
+            "ASSET",
+            "D0001",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "ACTIVE"
+        );
+
+        assertThatThrownBy(() -> inventoryService.create(request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("2000000002");
+    }
+
+    @Test
+    void updateModifiesExistingInventory() {
+        InventoryResponse created = inventoryService.create(
+            new InventoryRequest(
+                null,
+                "모터",
+                "ASSET",
+                "D0001",
+                "HYUNDAI",
+                "5HP",
+                "M-100",
+                "SN-XYZ",
+                null,
+                null,
+                "ACTIVE"
+            )
+        );
+
+        InventoryRequest updateRequest = new InventoryRequest(
+            created.inventoryId(),
+            "모터-수정",
+            "ASSET",
+            "D0003",
+            "HYUNDAI",
+            "7HP",
+            "M-100",
+            "SN-XYZ",
+            "FG-123",
+            "전압 변경",
+            "INACTIVE"
+        );
+
+        InventoryResponse updated = inventoryService.update(created.inventoryId(), updateRequest);
+
+        assertThat(updated.name()).isEqualTo("모터-수정");
+        assertThat(updated.deptId()).isEqualTo("D0003");
+        assertThat(updated.status()).isEqualTo("INACTIVE");
+    }
+
+    @Test
+    void deleteMarksInventoryAsDeleted() {
+        InventoryResponse created = inventoryService.create(
+            new InventoryRequest(
+                null,
+                "펌프",
+                "ASSET",
+                "D0001",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "ACTIVE"
+            )
+        );
+
+        inventoryService.delete(created.inventoryId());
+
+        Inventory saved = inventoryRepository
+            .findById(new InventoryId(MemberUserDetailsService.DEFAULT_COMPANY, created.inventoryId()))
+            .orElseThrow();
+        assertThat(saved.getDeleteMark()).isEqualTo("Y");
+    }
+
+    @Test
+    void getThrowsWhenInventoryMissing() {
+        assertThatThrownBy(() -> inventoryService.get("2999999999"))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void listReturnsActiveInventoriesMatchingKeyword() {
+        inventoryService.create(
+            new InventoryRequest(
+                null,
+                "볼트 M10",
+                "ASSET",
+                "D0001",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "ACTIVE"
+            )
+        );
+        inventoryService.create(
+            new InventoryRequest(
+                null,
+                "볼트 M12",
+                "ASSET",
+                "D0001",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "ACTIVE"
+            )
+        );
+        InventoryResponse deleted = inventoryService.create(
+            new InventoryRequest(
+                null,
+                "와셔",
+                "ASSET",
+                "D0001",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "ACTIVE"
+            )
+        );
+        inventoryService.delete(deleted.inventoryId());
+
+        Page<InventoryResponse> page = inventoryService.list("볼트", PageRequest.of(0, 10));
+
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        assertThat(page.getContent()).allMatch(item -> item.name().contains("볼트"));
+    }
+}

--- a/src/test/java/com/cmms11/web/CompanyControllerTest.java
+++ b/src/test/java/com/cmms11/web/CompanyControllerTest.java
@@ -1,0 +1,123 @@
+package com.cmms11.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.config.SecurityConfig;
+import com.cmms11.domain.company.CompanyRequest;
+import com.cmms11.domain.company.CompanyResponse;
+import com.cmms11.domain.company.CompanyService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 이름: CompanyControllerTest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: CompanyController REST 엔드포인트에 대한 MVC 레이어 테스트.
+ */
+@WebMvcTest(controllers = CompanyController.class)
+@Import(SecurityConfig.class)
+class CompanyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CompanyService companyService;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @WithMockUser
+    @Test
+    void listCompaniesReturnsPagedResponse() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        CompanyResponse response = new CompanyResponse("C0001", "Sample Company", "memo", "N", now, "tester", now, "tester");
+        when(companyService.list(anyString(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/domain/companies").param("q", "Sample"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].companyId").value("C0001"))
+            .andExpect(jsonPath("$.content[0].name").value("Sample Company"));
+
+        verify(companyService).list(eq("Sample"), any(Pageable.class));
+    }
+
+    @WithMockUser
+    @Test
+    void createCompanyReturnsCreatedResponse() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        CompanyRequest request = new CompanyRequest("C1000", "New Company", "memo");
+        CompanyResponse response = new CompanyResponse("C1000", "New Company", "memo", "N", now, "tester", now, "tester");
+        when(companyService.create(any(CompanyRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/domain/companies")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.companyId").value("C1000"))
+            .andExpect(jsonPath("$.name").value("New Company"));
+
+        verify(companyService).create(any(CompanyRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void updateCompanyReturnsOkResponse() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        CompanyRequest request = new CompanyRequest("C1000", "Updated Company", "memo");
+        CompanyResponse response = new CompanyResponse("C1000", "Updated Company", "memo", "N", now, "tester", now, "tester");
+        when(companyService.update(eq("C1000"), any(CompanyRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/domain/companies/{companyId}", "C1000")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value("Updated Company"));
+
+        verify(companyService).update(eq("C1000"), any(CompanyRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void deleteCompanyReturnsNoContent() throws Exception {
+        doNothing().when(companyService).delete("C1000");
+
+        mockMvc.perform(delete("/api/domain/companies/{companyId}", "C1000").with(csrf()))
+            .andExpect(status().isNoContent());
+
+        verify(companyService).delete("C1000");
+    }
+}

--- a/src/test/java/com/cmms11/web/InventoryControllerTest.java
+++ b/src/test/java/com/cmms11/web/InventoryControllerTest.java
@@ -1,0 +1,198 @@
+package com.cmms11.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.config.SecurityConfig;
+import com.cmms11.inventory.InventoryRequest;
+import com.cmms11.inventory.InventoryResponse;
+import com.cmms11.inventory.InventoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 이름: InventoryControllerTest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: InventoryController REST 엔드포인트의 동작을 검증하는 MVC 테스트.
+ */
+@WebMvcTest(controllers = InventoryController.class)
+@Import(SecurityConfig.class)
+class InventoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private InventoryService inventoryService;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @WithMockUser
+    @Test
+    void listInventoriesReturnsPagedResult() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        InventoryResponse response = sampleResponse(now);
+        when(inventoryService.list(anyString(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/inventories").param("q", "베어링"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].inventoryId").value("2000000001"))
+            .andExpect(jsonPath("$.content[0].name").value("베어링"));
+
+        verify(inventoryService).list(anyString(), any(Pageable.class));
+    }
+
+    @WithMockUser
+    @Test
+    void getInventoryReturnsSuccess() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        InventoryResponse response = sampleResponse(now);
+        when(inventoryService.get("2000000001")).thenReturn(response);
+
+        mockMvc.perform(get("/api/inventories/{inventoryId}", "2000000001"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.inventoryId").value("2000000001"))
+            .andExpect(jsonPath("$.name").value("베어링"));
+
+        verify(inventoryService).get("2000000001");
+    }
+
+    @WithMockUser
+    @Test
+    void createInventoryReturnsCreatedResponse() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        InventoryRequest request = new InventoryRequest(
+            null,
+            "베어링",
+            "ASSET",
+            "D0001",
+            "SKF",
+            "6205ZZ",
+            "MODEL-01",
+            "SN-001",
+            "FG0001",
+            "예비 부품",
+            "ACTIVE"
+        );
+        InventoryResponse response = sampleResponse(now);
+        when(inventoryService.create(any(InventoryRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/inventories")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.inventoryId").value("2000000001"));
+
+        verify(inventoryService).create(any(InventoryRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void updateInventoryReturnsOkResponse() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        InventoryRequest request = new InventoryRequest(
+            "2000000001",
+            "베어링-수정",
+            "ASSET",
+            "D0002",
+            "SKF",
+            "6205ZZ",
+            "MODEL-02",
+            "SN-002",
+            "FG0001",
+            "사양 변경",
+            "ACTIVE"
+        );
+        InventoryResponse response = new InventoryResponse(
+            "2000000001",
+            "베어링-수정",
+            "ASSET",
+            "D0002",
+            "SKF",
+            "6205ZZ",
+            "MODEL-02",
+            "SN-002",
+            "FG0001",
+            "사양 변경",
+            "ACTIVE",
+            "N",
+            now,
+            "tester",
+            now,
+            "tester"
+        );
+        when(inventoryService.update(anyString(), any(InventoryRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/inventories/{inventoryId}", "2000000001")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value("베어링-수정"));
+
+        verify(inventoryService).update(anyString(), any(InventoryRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void deleteInventoryReturnsNoContent() throws Exception {
+        doNothing().when(inventoryService).delete("2000000001");
+
+        mockMvc.perform(delete("/api/inventories/{inventoryId}", "2000000001").with(csrf()))
+            .andExpect(status().isNoContent());
+
+        verify(inventoryService).delete("2000000001");
+    }
+
+    private InventoryResponse sampleResponse(LocalDateTime timestamp) {
+        return new InventoryResponse(
+            "2000000001",
+            "베어링",
+            "ASSET",
+            "D0001",
+            "SKF",
+            "6205ZZ",
+            "MODEL-01",
+            "SN-001",
+            "FG0001",
+            "예비 부품",
+            "ACTIVE",
+            "N",
+            timestamp,
+            "tester",
+            timestamp,
+            "tester"
+        );
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:cmms11;MODE=MariaDB;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Summary
- implement service/dto/repository layers for inspection, workorder, workpermit, and memo modules with auto-numbering support
- add approval aggregate (header plus steps) along with repositories and service orchestration for workflow data
- replace inspection, workorder, workpermit, memo, and approval controller stubs with validated CRUD REST endpoints

## Testing
- not run (per instruction)

------
https://chatgpt.com/codex/tasks/task_e_68ce146306ac832395dfc13416a35287