### PR TITLE
Enable CSRF protection across UI

### DIFF
--- a/src/main/java/com/cmms11/config/SecurityConfig.java
+++ b/src/main/java/com/cmms11/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.cmms11.config;
 
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -10,15 +13,29 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        CookieCsrfTokenRepository tokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        tokenRepository.setCookiePath("/");
+
+        CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
+        requestHandler.setCsrfRequestAttributeName("_csrf");
+
         http
-            .csrf(csrf -> csrf.disable()) // TODO: enable and add CSRF tokens for forms
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(tokenRepository)
+                .csrfTokenRequestHandler(requestHandler)
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                     "/auth/**",
@@ -45,8 +62,28 @@ public class SecurityConfig {
                 .logoutSuccessUrl("/auth/login.html")
                 .invalidateHttpSession(true)
                 .deleteCookies("JSESSIONID")
+            )
+            .exceptionHandling(exception -> exception
+                .accessDeniedHandler(accessDeniedHandler())
             );
         return http.build();
+    }
+
+    private AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            if (response.isCommitted()) {
+                return;
+            }
+
+            log.warn(
+                "Access denied for {} {} - {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                accessDeniedException.getMessage()
+            );
+
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        };
     }
 
     @Bean

--- a/src/main/java/com/cmms11/web/CsrfControllerAdvice.java
+++ b/src/main/java/com/cmms11/web/CsrfControllerAdvice.java
@@ -1,0 +1,17 @@
+package com.cmms11.web;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class CsrfControllerAdvice {
+
+    @ModelAttribute
+    public void addCsrfToken(Model model, CsrfToken csrfToken) {
+        if (csrfToken != null) {
+            model.addAttribute("_csrf", csrfToken);
+        }
+    }
+}

--- a/src/main/resources/static/assets/js/app.js
+++ b/src/main/resources/static/assets/js/app.js
@@ -1,3 +1,153 @@
+const CSRF_COOKIE_NAME = 'XSRF-TOKEN';
+const CSRF_HEADER_NAME = 'X-CSRF-TOKEN';
+const CSRF_FORBIDDEN_ERROR = 'CsrfForbiddenError';
+
+const nativeFetch = window.fetch.bind(window);
+let csrfErrorDisplayed = false;
+
+function getCookieValue(name) {
+  if (typeof document === 'undefined') return null;
+  const cookieString = document.cookie || '';
+  const cookies = cookieString.split(';').map((c) => c.trim());
+  for (const cookie of cookies) {
+    if (!cookie) continue;
+    const [cookieName, ...rest] = cookie.split('=');
+    if (cookieName === name) {
+      return decodeURIComponent(rest.join('='));
+    }
+  }
+  return null;
+}
+
+function getCsrfToken() {
+  return getCookieValue(CSRF_COOKIE_NAME);
+}
+
+function ensureRequestWithHeader(input, init, token) {
+  if (!token) {
+    return { input, init };
+  }
+
+  if (input instanceof Request) {
+    const headers = new Headers(init?.headers || input.headers || undefined);
+    if (!headers.has(CSRF_HEADER_NAME)) {
+      headers.set(CSRF_HEADER_NAME, token);
+    }
+    const requestInit = { ...init, headers };
+    const request = new Request(input, requestInit);
+    return { input: request, init: undefined };
+  }
+
+  const options = init ? { ...init } : {};
+  const headers = new Headers(options.headers || undefined);
+  if (!headers.has(CSRF_HEADER_NAME)) {
+    headers.set(CSRF_HEADER_NAME, token);
+  }
+  options.headers = headers;
+  return { input, init: options };
+}
+
+function syncCsrfForms() {
+  if (typeof document === 'undefined') return;
+  const token = getCsrfToken();
+  const forms = document.querySelectorAll('form');
+  forms.forEach((form) => {
+    let field = form.querySelector('input[name="_csrf"]');
+    if (!field) {
+      field = document.createElement('input');
+      field.type = 'hidden';
+      field.name = '_csrf';
+      field.setAttribute('data-csrf-field', 'true');
+      form.appendChild(field);
+    }
+    if (token) {
+      field.value = token;
+    } else {
+      field.value = '';
+    }
+  });
+}
+
+function notifyCsrfError(detail) {
+  if (csrfErrorDisplayed) {
+    return;
+  }
+  csrfErrorDisplayed = true;
+
+  console.warn('CSRF protection blocked a request.', detail?.response || detail);
+
+  const loginError = document.getElementById('login_error');
+  if (loginError) {
+    loginError.textContent = '보안 토큰이 만료되었습니다. 페이지를 새로고침한 후 다시 시도하세요.';
+    loginError.setAttribute('role', 'alert');
+    loginError.style.display = 'block';
+  } else {
+    const slot = document.getElementById('layout-slot');
+    if (slot) {
+      slot.innerHTML = '';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'notice danger-text';
+      wrapper.setAttribute('role', 'alert');
+      wrapper.innerHTML = [
+        '<div>보안 검증에 실패했습니다. 세션이 만료되었을 수 있습니다.</div>',
+        '<div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap;">',
+        '  <button type="button" class="btn" data-csrf-retry>페이지 새로고침</button>',
+        '  <a class="btn" href="/auth/login.html?error=1&msg=' + encodeURIComponent('다시 로그인해 주세요.') + '">다시 로그인</a>',
+        '</div>'
+      ].join('');
+      slot.appendChild(wrapper);
+      const retry = wrapper.querySelector('[data-csrf-retry]');
+      if (retry) {
+        retry.addEventListener('click', () => {
+          csrfErrorDisplayed = false;
+          window.location.reload();
+        });
+      }
+    } else {
+      window.alert('보안 검증에 실패했습니다. 페이지를 새로고침한 후 다시 시도하세요.');
+    }
+  }
+
+  window.dispatchEvent(new CustomEvent('cmms:csrf-error', { detail }));
+}
+
+function createCsrfForbiddenError(response) {
+  const error = new Error('Forbidden');
+  error.name = CSRF_FORBIDDEN_ERROR;
+  error.response = response;
+  return error;
+}
+
+window.fetch = function csrfAwareFetch(input, init) {
+  const token = getCsrfToken();
+  let nextInput = input;
+  let nextInit = init;
+  if (token) {
+    const prepared = ensureRequestWithHeader(input, init, token);
+    nextInput = prepared.input;
+    nextInit = prepared.init;
+  }
+
+  return nativeFetch(nextInput, nextInit).then((response) => {
+    if (response.status === 403) {
+      response.csrfFailure = true;
+      notifyCsrfError({ response, request: { input: nextInput, init: nextInit } });
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', syncCsrfForms, { once: true });
+    } else {
+      syncCsrfForms();
+    }
+    return response;
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', syncCsrfForms, { once: true });
+} else {
+  syncCsrfForms();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const tableRows = document.querySelectorAll('[data-row-link]');
   tableRows.forEach((tr) => {

--- a/src/main/resources/templates/approval/form.html
+++ b/src/main/resources/templates/approval/form.html
@@ -36,6 +36,8 @@
       <main>
         <div class="container">
           <form class="stack" data-validate onsubmit="event.preventDefault(); alert('임시 저장된 것으로 가정합니다.');">
+
+            <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <section class="card">
               <div class="card-header">
                 <div class="card-title">결재 작성</div>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -22,9 +22,7 @@
               <label class="label" for="password">비밀번호</label>
               <input id="password" name="password" class="input" type="password" required maxlength="100" autocomplete="current-password" />
             </div>
-            <!-- 서버에서 CSRF 토큰을 제공할 경우 아래 hidden 필드 사용
-            <input type="hidden" name="_csrf" value="{{csrfToken}}" />
-            -->
+            <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <div id="login_error" class="notice danger-text" style="display:none;margin-top:12px"></div>
             <div class="actions" style="margin-top:16px">
               <button class="btn primary" type="submit">로그인</button>

--- a/src/main/resources/templates/code/form.html
+++ b/src/main/resources/templates/code/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 코드 타입 헤더 -->
                 <div class="section">
                   <div class="section-title">코드 타입</div>

--- a/src/main/resources/templates/domain/company/form.html
+++ b/src/main/resources/templates/domain/company/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">

--- a/src/main/resources/templates/domain/dept/form.html
+++ b/src/main/resources/templates/domain/dept/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">

--- a/src/main/resources/templates/domain/member/form.html
+++ b/src/main/resources/templates/domain/member/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/domain/site/form.html
+++ b/src/main/resources/templates/domain/site/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">

--- a/src/main/resources/templates/inspection/form.html
+++ b/src/main/resources/templates/inspection/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/inspection/plan.html
+++ b/src/main/resources/templates/inspection/plan.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 계획 대상(행 추가/삭제) -->
                 <div class="section" data-plan-items>
                   <div class="section-title">계획 대상</div>

--- a/src/main/resources/templates/inventory/form.html
+++ b/src/main/resources/templates/inventory/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/inventoryTx/transaction.html
+++ b/src/main/resources/templates/inventoryTx/transaction.html
@@ -52,6 +52,9 @@
               </div>
 
               <form data-validate>
+
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 입고: inventory_history.in_qty, unit_cost, amount; stock 가산 -->
                 <div class="section tx-panel active" data-panel="IN">
                   <div class="section-title">입고</div>

--- a/src/main/resources/templates/layout/defaultLayout.html
+++ b/src/main/resources/templates/layout/defaultLayout.html
@@ -153,6 +153,18 @@
     <script src="../assets/js/app.js"></script>
     <script>
       (function() {
+        const CSRF_ERROR_NAME = 'CsrfForbiddenError';
+
+        function toCsrfError(response) {
+          if (typeof createCsrfForbiddenError === 'function') {
+            return createCsrfForbiddenError(response);
+          }
+          const error = new Error('Forbidden');
+          error.name = CSRF_ERROR_NAME;
+          error.response = response;
+          return error;
+        }
+
         const slot = document.getElementById('layout-slot');
         if (!slot) return;
 
@@ -202,17 +214,28 @@
           currentContentUrl = contentUrl;
           if (opts.push === true) setState(contentUrl, true);
           fetch(contentUrl, { credentials: 'same-origin' })
-            .then(r => r.text())
+            .then(r => {
+              if (r.status === 403) {
+                throw toCsrfError(r);
+              }
+              return r.text();
+            })
             .then(html => {
               const parser = new DOMParser();
               const doc = parser.parseFromString(html, 'text/html');
               const main = doc.querySelector('main');
               slot.innerHTML = main ? main.innerHTML : (doc.body ? doc.body.innerHTML : html);
+              if (typeof syncCsrfForms === 'function') {
+                syncCsrfForms();
+              }
               setActive(currentContentUrl);
               const title = doc.querySelector('title');
               if (title && title.textContent) document.title = title.textContent + ' · CMMS';
             })
             .catch(err => {
+              if (err && err.name === CSRF_ERROR_NAME) {
+                return;
+              }
               slot.innerHTML = '<div class="notice danger-text">콘텐츠를 불러오지 못했습니다.</div>';
               console.error(err);
             });
@@ -236,6 +259,9 @@
                 window.location.href = '/auth/login.html';
                 return null;
               }
+              if (r.status === 403) {
+                throw toCsrfError(r);
+              }
               return r.ok ? r.json() : null;
             })
             .then(data => {
@@ -245,7 +271,10 @@
               el.textContent = `${name}${company}`;
               el.title = `ID: ${data.memberId || ''}${data.deptId ? `, 부서: ${data.deptId}` : ''}`.trim();
             })
-            .catch(() => {
+            .catch((err) => {
+              if (err && err.name === CSRF_ERROR_NAME) {
+                return;
+              }
               el.textContent = '사용자 정보 로드 실패';
             });
         })();

--- a/src/main/resources/templates/memo/form.html
+++ b/src/main/resources/templates/memo/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/plant/form.html
+++ b/src/main/resources/templates/plant/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/workorder/form.html
+++ b/src/main/resources/templates/workorder/form.html
@@ -38,6 +38,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>

--- a/src/main/resources/templates/workpermit/form.html
+++ b/src/main/resources/templates/workpermit/form.html
@@ -46,6 +46,8 @@
             </div>
             <div class="card-body">
               <form data-validate>
+
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <!-- 기본정보 -->
                 <div class="section">
                   <div class="section-title">기본정보</div>


### PR DESCRIPTION
## Summary
- enable CSRF protection with a cookie-backed token repository, request attribute handler, and access denied logging
- expose the CsrfToken to templates and embed hidden `_csrf` fields in login and other HTML forms
- extend the shared JavaScript to keep form fields in sync, attach `X-CSRF-TOKEN` on fetches, and surface friendly messaging on 403 responses

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68ce3329d3888323b8d21c8179cbaae8