### PR TITLE
feat: add func and storage domain modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.withType(Test) {

--- a/src/main/java/com/cmms11/domain/func/Func.java
+++ b/src/main/java/com/cmms11/domain/func/Func.java
@@ -1,0 +1,43 @@
+package com.cmms11.domain.func;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "func")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Func {
+    @EmbeddedId
+    private FuncId id;
+
+    @NotBlank
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String note;
+
+    @Column(name = "parent_id", length = 5)
+    private String parentId;
+
+    @Column(name = "delete_mark", length = 1)
+    private String deleteMark = "N";
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", length = 10)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 10)
+    private String updatedBy;
+}

--- a/src/main/java/com/cmms11/domain/func/FuncId.java
+++ b/src/main/java/com/cmms11/domain/func/FuncId.java
@@ -1,0 +1,24 @@
+package com.cmms11.domain.func;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class FuncId implements Serializable {
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "func_id", length = 5, nullable = false)
+    private String funcId;
+}

--- a/src/main/java/com/cmms11/domain/func/FuncRepository.java
+++ b/src/main/java/com/cmms11/domain/func/FuncRepository.java
@@ -1,0 +1,17 @@
+package com.cmms11.domain.func;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FuncRepository extends JpaRepository<Func, FuncId> {
+    Page<Func> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    @Query("select f from Func f where f.id.companyId=:companyId and f.deleteMark=:deleteMark and (f.id.funcId like :q or f.name like :q)")
+    Page<Func> search(@Param("companyId") String companyId,
+                      @Param("deleteMark") String deleteMark,
+                      @Param("q") String q,
+                      Pageable pageable);
+}

--- a/src/main/java/com/cmms11/domain/func/FuncService.java
+++ b/src/main/java/com/cmms11/domain/func/FuncService.java
@@ -1,0 +1,86 @@
+package com.cmms11.domain.func;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class FuncService {
+    private final FuncRepository repository;
+
+    public FuncService(FuncRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Func> list(String q, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        if (q == null || q.isBlank()) {
+            return repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        }
+        return repository.search(companyId, "N", "%" + q + "%", pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Func get(String funcId) {
+        FuncId id = new FuncId(MemberUserDetailsService.DEFAULT_COMPANY, funcId);
+        return repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Func not found: " + funcId));
+    }
+
+    public Func create(Func func) {
+        if (func.getId() == null || func.getId().getFuncId() == null || func.getId().getFuncId().isBlank()) {
+            throw new IllegalArgumentException("func.id.funcId is required");
+        }
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        func.getId().setCompanyId(companyId);
+        if (func.getDeleteMark() == null) {
+            func.setDeleteMark("N");
+        }
+        LocalDateTime now = LocalDateTime.now();
+        if (func.getCreatedAt() == null) {
+            func.setCreatedAt(now);
+        }
+        if (func.getUpdatedAt() == null) {
+            func.setUpdatedAt(now);
+        }
+        return repository.save(func);
+    }
+
+    public Func update(String funcId, Func func) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        FuncId id = new FuncId(companyId, funcId);
+        Func existing = repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Func not found: " + funcId));
+        func.setId(id);
+        if (func.getDeleteMark() == null) {
+            func.setDeleteMark(existing.getDeleteMark());
+        }
+        if (func.getCreatedAt() == null) {
+            func.setCreatedAt(existing.getCreatedAt());
+        }
+        if (func.getCreatedBy() == null) {
+            func.setCreatedBy(existing.getCreatedBy());
+        }
+        if (func.getUpdatedBy() == null) {
+            func.setUpdatedBy(existing.getUpdatedBy());
+        }
+        func.setUpdatedAt(LocalDateTime.now());
+        return repository.save(func);
+    }
+
+    public void delete(String funcId) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        FuncId id = new FuncId(companyId, funcId);
+        Func existing = repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Func not found: " + funcId));
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        repository.save(existing);
+    }
+}

--- a/src/main/java/com/cmms11/domain/storage/Storage.java
+++ b/src/main/java/com/cmms11/domain/storage/Storage.java
@@ -1,0 +1,43 @@
+package com.cmms11.domain.storage;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "storage")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Storage {
+    @EmbeddedId
+    private StorageId id;
+
+    @NotBlank
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String note;
+
+    @Column(name = "parent_id", length = 5)
+    private String parentId;
+
+    @Column(name = "delete_mark", length = 1)
+    private String deleteMark = "N";
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", length = 10)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 10)
+    private String updatedBy;
+}

--- a/src/main/java/com/cmms11/domain/storage/StorageId.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageId.java
@@ -1,0 +1,24 @@
+package com.cmms11.domain.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class StorageId implements Serializable {
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "storage_id", length = 5, nullable = false)
+    private String storageId;
+}

--- a/src/main/java/com/cmms11/domain/storage/StorageRepository.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageRepository.java
@@ -1,0 +1,17 @@
+package com.cmms11.domain.storage;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StorageRepository extends JpaRepository<Storage, StorageId> {
+    Page<Storage> findByIdCompanyIdAndDeleteMark(String companyId, String deleteMark, Pageable pageable);
+
+    @Query("select s from Storage s where s.id.companyId=:companyId and s.deleteMark=:deleteMark and (s.id.storageId like :q or s.name like :q)")
+    Page<Storage> search(@Param("companyId") String companyId,
+                         @Param("deleteMark") String deleteMark,
+                         @Param("q") String q,
+                         Pageable pageable);
+}

--- a/src/main/java/com/cmms11/domain/storage/StorageService.java
+++ b/src/main/java/com/cmms11/domain/storage/StorageService.java
@@ -1,0 +1,86 @@
+package com.cmms11.domain.storage;
+
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class StorageService {
+    private final StorageRepository repository;
+
+    public StorageService(StorageRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Storage> list(String q, Pageable pageable) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        if (q == null || q.isBlank()) {
+            return repository.findByIdCompanyIdAndDeleteMark(companyId, "N", pageable);
+        }
+        return repository.search(companyId, "N", "%" + q + "%", pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Storage get(String storageId) {
+        StorageId id = new StorageId(MemberUserDetailsService.DEFAULT_COMPANY, storageId);
+        return repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Storage not found: " + storageId));
+    }
+
+    public Storage create(Storage storage) {
+        if (storage.getId() == null || storage.getId().getStorageId() == null || storage.getId().getStorageId().isBlank()) {
+            throw new IllegalArgumentException("storage.id.storageId is required");
+        }
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        storage.getId().setCompanyId(companyId);
+        if (storage.getDeleteMark() == null) {
+            storage.setDeleteMark("N");
+        }
+        LocalDateTime now = LocalDateTime.now();
+        if (storage.getCreatedAt() == null) {
+            storage.setCreatedAt(now);
+        }
+        if (storage.getUpdatedAt() == null) {
+            storage.setUpdatedAt(now);
+        }
+        return repository.save(storage);
+    }
+
+    public Storage update(String storageId, Storage storage) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        StorageId id = new StorageId(companyId, storageId);
+        Storage existing = repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Storage not found: " + storageId));
+        storage.setId(id);
+        if (storage.getDeleteMark() == null) {
+            storage.setDeleteMark(existing.getDeleteMark());
+        }
+        if (storage.getCreatedAt() == null) {
+            storage.setCreatedAt(existing.getCreatedAt());
+        }
+        if (storage.getCreatedBy() == null) {
+            storage.setCreatedBy(existing.getCreatedBy());
+        }
+        if (storage.getUpdatedBy() == null) {
+            storage.setUpdatedBy(existing.getUpdatedBy());
+        }
+        storage.setUpdatedAt(LocalDateTime.now());
+        return repository.save(storage);
+    }
+
+    public void delete(String storageId) {
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+        StorageId id = new StorageId(companyId, storageId);
+        Storage existing = repository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Storage not found: " + storageId));
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        repository.save(existing);
+    }
+}

--- a/src/main/java/com/cmms11/web/FuncController.java
+++ b/src/main/java/com/cmms11/web/FuncController.java
@@ -1,0 +1,48 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.func.Func;
+import com.cmms11.domain.func.FuncService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/domain/funcs")
+public class FuncController {
+    private final FuncService service;
+
+    public FuncController(FuncService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<Func> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{funcId}")
+    public ResponseEntity<Func> get(@PathVariable String funcId) {
+        return ResponseEntity.ok(service.get(funcId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Func> create(@Valid @RequestBody Func func) {
+        Func saved = service.create(func);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PutMapping("/{funcId}")
+    public ResponseEntity<Func> update(@PathVariable String funcId, @Valid @RequestBody Func func) {
+        Func updated = service.update(funcId, func);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{funcId}")
+    public ResponseEntity<Void> delete(@PathVariable String funcId) {
+        service.delete(funcId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/cmms11/web/StorageController.java
+++ b/src/main/java/com/cmms11/web/StorageController.java
@@ -1,0 +1,48 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.storage.Storage;
+import com.cmms11.domain.storage.StorageService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/domain/storages")
+public class StorageController {
+    private final StorageService service;
+
+    public StorageController(StorageService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<Storage> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+        return service.list(q, pageable);
+    }
+
+    @GetMapping("/{storageId}")
+    public ResponseEntity<Storage> get(@PathVariable String storageId) {
+        return ResponseEntity.ok(service.get(storageId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Storage> create(@Valid @RequestBody Storage storage) {
+        Storage saved = service.create(storage);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PutMapping("/{storageId}")
+    public ResponseEntity<Storage> update(@PathVariable String storageId, @Valid @RequestBody Storage storage) {
+        Storage updated = service.update(storageId, storage);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{storageId}")
+    public ResponseEntity<Void> delete(@PathVariable String storageId) {
+        service.delete(storageId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/resources/templates/domain/func/form.html
+++ b/src/main/resources/templates/domain/func/form.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>기능 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <a href="list.html">설비 기능</a>
+          <span class="sep">/</span>
+          <span>등록/수정</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">기능 등록/수정</div>
+              <div class="toolbar">
+                <a class="btn" href="list.html">목록</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <form data-validate>
+                <div class="section">
+                  <div class="section-title">기본정보</div>
+                  <div class="grid cols-12">
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="func_id">기능코드</label>
+                      <input id="func_id" name="func_id" class="input" required maxlength="5" placeholder="예: F0001" />
+                    </div>
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="func_name">기능명</label>
+                      <input id="func_name" name="func_name" class="input" required maxlength="100" />
+                    </div>
+                    <div class="form-row col-span-4">
+                      <label class="label" for="parent_id">상위기능</label>
+                      <select id="parent_id" name="parent_id">
+                        <option value="">(없음)</option>
+                        <option value="F0001">F0001 - 공정관리</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="form-row col-span-12">
+                    <label class="label" for="note">비고</label>
+                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기능에 대한 추가 설명"></textarea>
+                  </div>
+                </div>
+
+                <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
+                  <button class="btn" type="reset">초기화</button>
+                  <button class="btn primary" type="submit">저장</button>
+                </div>
+              </form>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/domain/func/list.html
+++ b/src/main/resources/templates/domain/func/list.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>기능 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>설비 기능</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">기능 목록</div>
+              <div class="toolbar">
+                <a class="btn" href="#">정보보기</a>
+                <a class="btn primary" href="form.html">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="section">
+                <div class="section-title">필터</div>
+                <div class="grid cols-12">
+                  <div class="col-span-3">
+                    <input class="input" placeholder="기능코드" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="기능명" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="상위기능" />
+                  </div>
+                  <div class="col-span-3" style="display:flex;gap:8px;justify-content:flex-end">
+                    <button class="btn">초기화</button>
+                    <button class="btn">검색</button>
+                  </div>
+                </div>
+              </div>
+
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width:140px">기능코드</th>
+                    <th>기능명</th>
+                    <th style="width:160px">상위기능</th>
+                    <th style="width:220px">비고</th>
+                    <th style="width:120px">상태</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-row-link="form.html">
+                    <td><a href="form.html">F0001</a></td>
+                    <td>공정관리</td>
+                    <td>(없음)</td>
+                    <td>주요 공정 관리 기능</td>
+                    <td><span class="badge">정상</span></td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="row" style="margin-top:12px">
+                <div class="spacer"></div>
+                <div class="pagination">
+                  <button class="btn sm" disabled>이전</button>
+                  <button class="btn sm">다음</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/domain/storage/form.html
+++ b/src/main/resources/templates/domain/storage/form.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>창고 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <a href="list.html">창고</a>
+          <span class="sep">/</span>
+          <span>등록/수정</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">창고 등록/수정</div>
+              <div class="toolbar">
+                <a class="btn" href="list.html">목록</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <form data-validate>
+                <div class="section">
+                  <div class="section-title">기본정보</div>
+                  <div class="grid cols-12">
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="storage_id">창고코드</label>
+                      <input id="storage_id" name="storage_id" class="input" required maxlength="5" placeholder="예: ST001" />
+                    </div>
+                    <div class="form-row col-span-4">
+                      <label class="label required" for="storage_name">창고명</label>
+                      <input id="storage_name" name="storage_name" class="input" required maxlength="100" />
+                    </div>
+                    <div class="form-row col-span-4">
+                      <label class="label" for="parent_id">상위창고</label>
+                      <select id="parent_id" name="parent_id">
+                        <option value="">(없음)</option>
+                        <option value="ST001">ST001 - 메인창고</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="form-row col-span-12">
+                    <label class="label" for="note">비고</label>
+                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="창고에 대한 설명"></textarea>
+                  </div>
+                </div>
+
+                <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
+                  <button class="btn" type="reset">초기화</button>
+                  <button class="btn primary" type="submit">저장</button>
+                </div>
+              </form>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/domain/storage/list.html
+++ b/src/main/resources/templates/domain/storage/list.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>창고 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>운영중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>창고</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">창고 목록</div>
+              <div class="toolbar">
+                <a class="btn" href="#">정보보기</a>
+                <a class="btn primary" href="form.html">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="section">
+                <div class="section-title">필터</div>
+                <div class="grid cols-12">
+                  <div class="col-span-3">
+                    <input class="input" placeholder="창고코드" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="창고명" />
+                  </div>
+                  <div class="col-span-3">
+                    <input class="input" placeholder="상위창고" />
+                  </div>
+                  <div class="col-span-3" style="display:flex;gap:8px;justify-content:flex-end">
+                    <button class="btn">초기화</button>
+                    <button class="btn">검색</button>
+                  </div>
+                </div>
+              </div>
+
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width:140px">창고코드</th>
+                    <th>창고명</th>
+                    <th style="width:160px">상위창고</th>
+                    <th style="width:220px">비고</th>
+                    <th style="width:120px">상태</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-row-link="form.html">
+                    <td><a href="form.html">ST001</a></td>
+                    <td>메인창고</td>
+                    <td>(없음)</td>
+                    <td>주요 자재 보관</td>
+                    <td><span class="badge">정상</span></td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="row" style="margin-top:12px">
+                <div class="spacer"></div>
+                <div class="pagination">
+                  <button class="btn sm" disabled>이전</button>
+                  <button class="btn sm">다음</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/test/java/com/cmms11/web/FuncControllerTest.java
+++ b/src/test/java/com/cmms11/web/FuncControllerTest.java
@@ -1,0 +1,121 @@
+package com.cmms11.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.domain.func.Func;
+import com.cmms11.domain.func.FuncId;
+import com.cmms11.domain.func.FuncRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@WithMockUser(username = "admin")
+class FuncControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FuncRepository repository;
+
+    @Test
+    void listFunctionsSupportsPaginationAndSearch() throws Exception {
+        saveFunc("F0001", "공정관리");
+        saveFunc("F0002", "유틸리티");
+
+        mockMvc.perform(get("/api/domain/funcs").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()", is(2)));
+
+        mockMvc.perform(get("/api/domain/funcs")
+                        .param("q", "유틸")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()", is(1)))
+                .andExpect(jsonPath("$.content[0].name").value("유틸리티"));
+    }
+
+    @Test
+    void createUpdateAndDeleteFunc() throws Exception {
+        String createPayload = """
+            {
+              \"id\": {\"funcId\": \"F0100\"},
+              \"name\": \"안전관리\",
+              \"note\": \"신규 기능\"
+            }
+            """;
+
+        mockMvc.perform(post("/api/domain/funcs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createPayload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id.funcId").value("F0100"))
+                .andExpect(jsonPath("$.deleteMark").value("N"));
+
+        FuncId id = new FuncId("C0001", "F0100");
+        Func saved = repository.findById(id).orElseThrow();
+        assertThat(saved.getDeleteMark()).isEqualTo("N");
+
+        String updatePayload = """
+            {
+              \"name\": \"안전관리\",
+              \"note\": \"점검 주관 부서\",
+              \"updatedBy\": \"tester\"
+            }
+            """;
+
+        mockMvc.perform(put("/api/domain/funcs/{funcId}", "F0100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updatePayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.note").value("점검 주관 부서"))
+                .andExpect(jsonPath("$.updatedBy").value("tester"));
+
+        mockMvc.perform(delete("/api/domain/funcs/{funcId}", "F0100"))
+                .andExpect(status().isNoContent());
+
+        Func deleted = repository.findById(id).orElseThrow();
+        assertThat(deleted.getDeleteMark()).isEqualTo("Y");
+    }
+
+    @Test
+    void funcTemplatesAreServedThroughLayout() throws Exception {
+        mockMvc.perform(get("/domain/func/list.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("기능 목록")));
+
+        mockMvc.perform(get("/domain/func/form.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("기능 등록/수정")));
+    }
+
+    private void saveFunc(String funcId, String name) {
+        Func func = new Func();
+        func.setId(new FuncId("C0001", funcId));
+        func.setName(name);
+        func.setDeleteMark("N");
+        func.setCreatedAt(LocalDateTime.now());
+        func.setUpdatedAt(LocalDateTime.now());
+        repository.save(func);
+    }
+}

--- a/src/test/java/com/cmms11/web/StorageControllerTest.java
+++ b/src/test/java/com/cmms11/web/StorageControllerTest.java
@@ -1,0 +1,121 @@
+package com.cmms11.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.domain.storage.Storage;
+import com.cmms11.domain.storage.StorageId;
+import com.cmms11.domain.storage.StorageRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@WithMockUser(username = "admin")
+class StorageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StorageRepository repository;
+
+    @Test
+    void listStoragesSupportsPaginationAndSearch() throws Exception {
+        saveStorage("ST001", "메인창고");
+        saveStorage("ST002", "부자재창고");
+
+        mockMvc.perform(get("/api/domain/storages").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()", is(2)));
+
+        mockMvc.perform(get("/api/domain/storages")
+                        .param("q", "부자재")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()", is(1)))
+                .andExpect(jsonPath("$.content[0].name").value("부자재창고"));
+    }
+
+    @Test
+    void createUpdateAndDeleteStorage() throws Exception {
+        String createPayload = """
+            {
+              \"id\": {\"storageId\": \"ST100\"},
+              \"name\": \"예비창고\",
+              \"note\": \"임시 보관\"
+            }
+            """;
+
+        mockMvc.perform(post("/api/domain/storages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createPayload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id.storageId").value("ST100"))
+                .andExpect(jsonPath("$.deleteMark").value("N"));
+
+        StorageId id = new StorageId("C0001", "ST100");
+        Storage saved = repository.findById(id).orElseThrow();
+        assertThat(saved.getDeleteMark()).isEqualTo("N");
+
+        String updatePayload = """
+            {
+              \"name\": \"예비창고\",
+              \"note\": \"재고 초과분 보관\",
+              \"parentId\": \"ST001\"
+            }
+            """;
+
+        mockMvc.perform(put("/api/domain/storages/{storageId}", "ST100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updatePayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.note").value("재고 초과분 보관"))
+                .andExpect(jsonPath("$.parentId").value("ST001"));
+
+        mockMvc.perform(delete("/api/domain/storages/{storageId}", "ST100"))
+                .andExpect(status().isNoContent());
+
+        Storage deleted = repository.findById(id).orElseThrow();
+        assertThat(deleted.getDeleteMark()).isEqualTo("Y");
+    }
+
+    @Test
+    void storageTemplatesAreServedThroughLayout() throws Exception {
+        mockMvc.perform(get("/domain/storage/list.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("창고 목록")));
+
+        mockMvc.perform(get("/domain/storage/form.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("창고 등록/수정")));
+    }
+
+    private void saveStorage(String storageId, String name) {
+        Storage storage = new Storage();
+        storage.setId(new StorageId("C0001", storageId));
+        storage.setName(name);
+        storage.setDeleteMark("N");
+        storage.setCreatedAt(LocalDateTime.now());
+        storage.setUpdatedAt(LocalDateTime.now());
+        repository.save(storage);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:cmms11;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Summary
- add func and storage domain entities, repositories, and services with soft delete and audit behavior
- expose CRUD REST controllers and list/form templates for the new function and storage domains
- add integration tests with an H2-backed test profile to cover pagination, search, and CRUD flows

## Testing
- gradle test *(fails: dependency downloads blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ce333cd6f88323a2bc95edd7bfc2af