### PR TITLE
fix: reinitialize SPA layout forms with CSRF tokens

### DIFF
--- a/src/main/resources/static/assets/js/app.js
+++ b/src/main/resources/static/assets/js/app.js
@@ -1,124 +1,225 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const tableRows = document.querySelectorAll('[data-row-link]');
-  tableRows.forEach((tr) => {
-    tr.addEventListener('click', (e) => {
-      const clicked = e.target;
-      if (clicked instanceof Element && clicked.closest('a,button,input,select,textarea,label')) {
-        return; // let the element handle its own click
-      }
-      const target = e.currentTarget;
-      const href = target.getAttribute('data-row-link');
-      if (href) window.location.href = href;
-    });
-  });
+;(function (window, document) {
+  'use strict';
 
-  const confirmables = document.querySelectorAll('[data-confirm]');
-  confirmables.forEach((el) => {
-    el.addEventListener('click', (e) => {
-      const msg = el.getAttribute('data-confirm') || '확인하시겠습니까?';
-      if (!confirm(msg)) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    });
-  });
+  function findAll(root, selector) {
+    if (!root) return [];
+    const nodes = [];
+    if (root instanceof Element && root.matches(selector)) {
+      nodes.push(root);
+    }
+    const scoped = root.querySelectorAll ? root.querySelectorAll(selector) : [];
+    return nodes.concat(Array.from(scoped));
+  }
 
-  const forms = document.querySelectorAll('form[data-validate]');
-  forms.forEach((form) => {
-    form.addEventListener('submit', (e) => {
-      if (!form.checkValidity()) {
-        e.preventDefault();
-        const firstInvalid = form.querySelector(':invalid');
-        firstInvalid?.focus();
-      }
-    });
-  });
+  function formatFileSize(bytes) {
+    if (!bytes) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const size = bytes / Math.pow(k, i);
+    return `${parseFloat(size.toFixed(2))} ${sizes[i]}`;
+  }
 
-  // 파일 첨부 기능
-  const attachmentSections = document.querySelectorAll('[data-attachments]');
-  attachmentSections.forEach((section) => {
-    const fileInput = section.querySelector('#attachments-input');
-    const addButton = section.querySelector('[data-attachments-add]');
-    const attachmentsList = section.querySelector('.attachments-list');
-    
-    if (!fileInput || !addButton || !attachmentsList) return;
-    
-    // 파일 선택 버튼 클릭 시 파일 입력창 열기
-    addButton.addEventListener('click', () => {
-      fileInput.click();
-    });
-    
-    // 파일 선택 시 목록에 추가
-    fileInput.addEventListener('change', (e) => {
-      const files = Array.from(e.target.files);
-      
-      if (files.length === 0) return;
-      
-      // 빈 메시지 제거
-      const emptyMessage = attachmentsList.querySelector('.empty');
-      if (emptyMessage) {
-        emptyMessage.remove();
-      }
-      
-      // 선택된 파일들을 목록에 추가
-      files.forEach((file) => {
-        const listItem = createAttachmentListItem(file);
-        attachmentsList.appendChild(listItem);
-      });
-      
-      // 파일 입력 초기화 (같은 파일을 다시 선택할 수 있도록)
-      fileInput.value = '';
-    });
-  });
-  
-  // 첨부 파일 목록 아이템 생성 함수
-  function createAttachmentListItem(file) {
-    const li = document.createElement('li');
+  function createAttachmentListItem(file, doc) {
+    const documentRef = doc || document;
+    const li = documentRef.createElement('li');
     li.className = 'attachment-item';
-    
-    const fileName = document.createElement('span');
+
+    const fileName = documentRef.createElement('span');
     fileName.className = 'file-name';
     fileName.textContent = file.name;
-    
-    const fileSize = document.createElement('span');
+
+    const fileSize = documentRef.createElement('span');
     fileSize.className = 'file-size';
     fileSize.textContent = formatFileSize(file.size);
-    
-    const removeButton = document.createElement('button');
+
+    const removeButton = documentRef.createElement('button');
     removeButton.type = 'button';
     removeButton.className = 'btn-remove';
     removeButton.textContent = '제거';
     removeButton.setAttribute('aria-label', `${file.name} 파일 제거`);
-    
-    // 파일 제거 기능
+
     removeButton.addEventListener('click', () => {
+      const list = li.parentElement;
       li.remove();
-      
-      // 모든 파일이 제거되면 빈 메시지 표시
-      const remainingItems = li.parentElement.querySelectorAll('.attachment-item');
-      if (remainingItems.length === 1) { // 현재 제거되는 항목 포함
-        const emptyMessage = document.createElement('li');
+      if (!list) return;
+      const remainingItems = list.querySelectorAll('.attachment-item');
+      if (remainingItems.length === 1) {
+        const emptyMessage = documentRef.createElement('li');
         emptyMessage.className = 'empty';
         emptyMessage.textContent = '첨부된 파일이 없습니다.';
-        li.parentElement.appendChild(emptyMessage);
+        list.appendChild(emptyMessage);
       }
     });
-    
+
     li.appendChild(fileName);
     li.appendChild(fileSize);
     li.appendChild(removeButton);
-    
+
     return li;
   }
-  
-  // 파일 크기 포맷팅 함수
-  function formatFileSize(bytes) {
-    if (bytes === 0) return '0 Bytes';
-    
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+
+  function initRowLinks(root = document) {
+    findAll(root, '[data-row-link]').forEach((row) => {
+      if (!(row instanceof HTMLElement)) return;
+      if (row.dataset.cmmsRowLinkBound === 'true') return;
+      row.dataset.cmmsRowLinkBound = 'true';
+      row.addEventListener('click', (event) => {
+        const clicked = event.target;
+        if (clicked instanceof Element && clicked.closest('a,button,input,select,textarea,label')) {
+          return;
+        }
+        const target = event.currentTarget;
+        if (target instanceof HTMLElement) {
+          const href = target.getAttribute('data-row-link');
+          if (href) window.location.href = href;
+        }
+      });
+    });
   }
-});
+
+  function initConfirmables(root = document) {
+    findAll(root, '[data-confirm]').forEach((element) => {
+      if (!(element instanceof HTMLElement)) return;
+      if (element.dataset.cmmsConfirmBound === 'true') return;
+      element.dataset.cmmsConfirmBound = 'true';
+      element.addEventListener('click', (event) => {
+        const message = element.getAttribute('data-confirm') || '확인하시겠습니까?';
+        if (!window.confirm(message)) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      });
+    });
+  }
+
+  function initFormValidation(root = document) {
+    findAll(root, 'form[data-validate]').forEach((form) => {
+      if (!(form instanceof HTMLFormElement)) return;
+      if (form.dataset.cmmsValidateBound === 'true') return;
+      form.dataset.cmmsValidateBound = 'true';
+      form.addEventListener('submit', (event) => {
+        if (form.checkValidity()) return;
+        event.preventDefault();
+        const firstInvalid = form.querySelector(':invalid');
+        if (firstInvalid instanceof HTMLElement) {
+          firstInvalid.focus();
+        }
+      });
+    });
+  }
+
+  function initAttachments(root = document) {
+    findAll(root, '[data-attachments]').forEach((section) => {
+      if (!(section instanceof HTMLElement)) return;
+      if (section.dataset.cmmsAttachmentsBound === 'true') return;
+      const fileInput = section.querySelector('#attachments-input');
+      const addButton = section.querySelector('[data-attachments-add]');
+      const attachmentsList = section.querySelector('.attachments-list');
+      if (!fileInput || !addButton || !attachmentsList) return;
+      section.dataset.cmmsAttachmentsBound = 'true';
+      addButton.addEventListener('click', () => {
+        if (fileInput instanceof HTMLInputElement) {
+          fileInput.click();
+        }
+      });
+      fileInput.addEventListener('change', (event) => {
+        const input = event.target;
+        if (!(input instanceof HTMLInputElement) || !input.files) return;
+        const files = Array.from(input.files);
+        if (files.length === 0) return;
+        const emptyMessage = attachmentsList.querySelector('.empty');
+        emptyMessage?.remove();
+        const docRef = section.ownerDocument || document;
+        files.forEach((file) => {
+          const listItem = createAttachmentListItem(file, docRef);
+          attachmentsList.appendChild(listItem);
+        });
+        input.value = '';
+      });
+    });
+  }
+
+  function getCookie(name) {
+    const cookieString = document.cookie || '';
+    const cookies = cookieString.split(';');
+    for (let i = 0; i < cookies.length; i += 1) {
+      const cookie = cookies[i].trim();
+      if (cookie.startsWith(`${name}=`)) {
+        return decodeURIComponent(cookie.substring(name.length + 1));
+      }
+    }
+    return '';
+  }
+
+  function resolveCsrfToken() {
+    const meta = document.querySelector('meta[name="_csrf"]');
+    const metaToken = meta?.getAttribute('content')?.trim();
+    if (metaToken) return metaToken;
+    const candidates = ['XSRF-TOKEN', 'XSRF_TOKEN', '_csrf'];
+    for (let i = 0; i < candidates.length; i += 1) {
+      const token = getCookie(candidates[i]);
+      if (token) return token;
+    }
+    return '';
+  }
+
+  function syncCsrfHiddenFields(root = document) {
+    const token = resolveCsrfToken();
+    if (!token) return;
+    const docRef = root instanceof Document ? root : root?.ownerDocument || document;
+    const forms = findAll(root, 'form');
+    forms.forEach((form) => {
+      if (!(form instanceof HTMLFormElement)) return;
+      if (form.hasAttribute('data-skip-csrf')) return;
+      let input = form.querySelector('input[name="_csrf"]');
+      if (!input) {
+        input = docRef.createElement('input');
+        input.type = 'hidden';
+        input.name = '_csrf';
+        form.appendChild(input);
+      }
+      input.value = token;
+    });
+    if (docRef && docRef !== document) {
+      const meta = document.querySelector('meta[name="_csrf"]');
+      if (meta && !meta.getAttribute('content')) {
+        meta.setAttribute('content', token);
+      }
+    }
+  }
+
+  function initialize(root = document) {
+    syncCsrfHiddenFields(root);
+    initRowLinks(root);
+    initConfirmables(root);
+    initFormValidation(root);
+    initAttachments(root);
+    if (typeof window.CustomEvent === 'function') {
+      const event = new window.CustomEvent('cmms:init', { detail: { root } });
+      document.dispatchEvent(event);
+    }
+  }
+
+  function onReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  const api = {
+    init: initialize,
+    initAttachments,
+    initConfirmables,
+    initFormValidation,
+    initRowLinks,
+    syncCsrfHiddenFields,
+  };
+
+  window.CMMSApp = Object.assign({}, window.CMMSApp || {}, api);
+  window.syncCsrfHiddenFields = syncCsrfHiddenFields;
+
+  onReady(() => initialize(document));
+})(window, document);

--- a/src/main/resources/templates/layout/defaultLayout.html
+++ b/src/main/resources/templates/layout/defaultLayout.html
@@ -208,6 +208,11 @@
               const doc = parser.parseFromString(html, 'text/html');
               const main = doc.querySelector('main');
               slot.innerHTML = main ? main.innerHTML : (doc.body ? doc.body.innerHTML : html);
+              if (window.CMMSApp && typeof window.CMMSApp.init === 'function') {
+                window.CMMSApp.init(slot);
+              } else if (typeof window.syncCsrfHiddenFields === 'function') {
+                window.syncCsrfHiddenFields(slot);
+              }
               setActive(currentContentUrl);
               const title = doc.querySelector('title');
               if (title && title.textContent) document.title = title.textContent + ' · CMMS';


### PR DESCRIPTION
## Summary
- expose reusable app initialization helpers and CSRF synchronisation from `static/assets/js/app.js`
- invoke the shared initializer after layout content swaps so dynamically loaded forms receive tokens and bindings

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68ce334c0b2c83239cbb118b1a68bf93