### PR TITLE
fix: enforce two-decimal move qty in inventory closing

### DIFF
--- a/src/main/java/com/cmms11/inventoryTx/InventoryClosing.java
+++ b/src/main/java/com/cmms11/inventoryTx/InventoryClosing.java
@@ -2,6 +2,7 @@ package com.cmms11.inventoryTx;
 
 import jakarta.persistence.*;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,7 +36,7 @@ public class InventoryClosing {
     @Column(name = "out_amount", precision = 18, scale = 2)
     private BigDecimal outAmount;
 
-    @Column(name = "move_qty", precision = 18, scale = 3)
+    @Column(name = "move_qty", precision = 18, scale = 2)
     private BigDecimal moveQty;
 
     @Column(name = "move_amount", precision = 18, scale = 2)
@@ -61,4 +62,8 @@ public class InventoryClosing {
 
     @Column(name = "closed_by", length = 10)
     private String closedBy;
+
+    public void setMoveQty(BigDecimal moveQty) {
+        this.moveQty = moveQty != null ? moveQty.setScale(2, RoundingMode.HALF_UP) : null;
+    }
 }

--- a/src/main/resources/db/migration/V2__adjust_inventory_closing_move_qty_scale.sql
+++ b/src/main/resources/db/migration/V2__adjust_inventory_closing_move_qty_scale.sql
@@ -1,0 +1,7 @@
+-- Ensure move_qty values align to two decimal places before altering column scale
+UPDATE inventory_closing
+SET move_qty = ROUND(move_qty, 2)
+WHERE move_qty IS NOT NULL AND move_qty <> ROUND(move_qty, 2);
+
+ALTER TABLE inventory_closing
+    MODIFY move_qty DECIMAL(18,2);


### PR DESCRIPTION
## Summary
- update the InventoryClosing entity so move quantities persist with a DECIMAL(18,2) scale and are rounded via the setter
- add a Flyway migration to round existing move_qty values and alter the column definition to DECIMAL(18,2)

## Testing
- `./gradlew test` *(fails: Gradle wrapper could not download due to proxy 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7e8a954c8323a257d72d23e0e01b