### PR TITLE
feat: add inspection item management

### DIFF
--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -240,12 +240,14 @@ CREATE TABLE inspection (
 CREATE TABLE inspection_item (
   company_id CHAR(5),
   inspection_id CHAR(10),
-  line_no INTEGER, 
+  line_no INTEGER,
   name  VARCHAR(100),
   method     VARCHAR(100),
   min_val   VARCHAR(50),
   max_val   VARCHAR(50),
   std_val   VARCHAR(50),
+  unit       VARCHAR(50),
+  result_val VARCHAR(50),
   note       VARCHAR(500),
   CONSTRAINT pk_inspection_item PRIMARY KEY (company_id, inspection_id,line_no)
 );

--- a/src/main/java/com/cmms11/inspection/InspectionItem.java
+++ b/src/main/java/com/cmms11/inspection/InspectionItem.java
@@ -1,0 +1,44 @@
+package com.cmms11.inspection;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "inspection_item")
+@Getter
+@Setter
+@NoArgsConstructor
+public class InspectionItem {
+
+    @EmbeddedId
+    private InspectionItemId id;
+
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 100)
+    private String method;
+
+    @Column(name = "min_val", length = 50)
+    private String minVal;
+
+    @Column(name = "max_val", length = 50)
+    private String maxVal;
+
+    @Column(name = "std_val", length = 50)
+    private String stdVal;
+
+    @Column(length = 50)
+    private String unit;
+
+    @Column(name = "result_val", length = 50)
+    private String resultVal;
+
+    @Column(length = 500)
+    private String note;
+}

--- a/src/main/java/com/cmms11/inspection/InspectionItemId.java
+++ b/src/main/java/com/cmms11/inspection/InspectionItemId.java
@@ -1,0 +1,28 @@
+package com.cmms11.inspection;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class InspectionItemId implements Serializable {
+
+    @Column(name = "company_id", length = 5, nullable = false)
+    private String companyId;
+
+    @Column(name = "inspection_id", length = 10, nullable = false)
+    private String inspectionId;
+
+    @Column(name = "line_no", nullable = false)
+    private Integer lineNo;
+}

--- a/src/main/java/com/cmms11/inspection/InspectionItemRepository.java
+++ b/src/main/java/com/cmms11/inspection/InspectionItemRepository.java
@@ -1,0 +1,10 @@
+package com.cmms11.inspection;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InspectionItemRepository extends JpaRepository<InspectionItem, InspectionItemId> {
+    List<InspectionItem> findByIdCompanyIdAndIdInspectionIdOrderByIdLineNo(String companyId, String inspectionId);
+
+    void deleteByIdCompanyIdAndIdInspectionId(String companyId, String inspectionId);
+}

--- a/src/main/java/com/cmms11/inspection/InspectionItemRequest.java
+++ b/src/main/java/com/cmms11/inspection/InspectionItemRequest.java
@@ -1,0 +1,15 @@
+package com.cmms11.inspection;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InspectionItemRequest(
+    @NotBlank @Size(max = 100) String name,
+    @Size(max = 100) String method,
+    @Size(max = 50) String minVal,
+    @Size(max = 50) String maxVal,
+    @Size(max = 50) String stdVal,
+    @Size(max = 50) String unit,
+    @Size(max = 50) String resultVal,
+    @Size(max = 500) String note
+) {}

--- a/src/main/java/com/cmms11/inspection/InspectionItemResponse.java
+++ b/src/main/java/com/cmms11/inspection/InspectionItemResponse.java
@@ -1,0 +1,28 @@
+package com.cmms11.inspection;
+
+public record InspectionItemResponse(
+    Integer lineNo,
+    String name,
+    String method,
+    String minVal,
+    String maxVal,
+    String stdVal,
+    String unit,
+    String resultVal,
+    String note
+) {
+    public static InspectionItemResponse from(InspectionItem entity) {
+        Integer lineNo = entity.getId() != null ? entity.getId().getLineNo() : null;
+        return new InspectionItemResponse(
+            lineNo,
+            entity.getName(),
+            entity.getMethod(),
+            entity.getMinVal(),
+            entity.getMaxVal(),
+            entity.getStdVal(),
+            entity.getUnit(),
+            entity.getResultVal(),
+            entity.getNote()
+        );
+    }
+}

--- a/src/main/java/com/cmms11/inspection/InspectionRequest.java
+++ b/src/main/java/com/cmms11/inspection/InspectionRequest.java
@@ -1,8 +1,10 @@
 package com.cmms11.inspection;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 이름: InspectionRequest
@@ -23,6 +25,10 @@ public record InspectionRequest(
     LocalDate actualDate,
     @Size(max = 10) String status,
     @Size(max = 100) String fileGroupId,
-    @Size(max = 500) String note
+    @Size(max = 500) String note,
+    List<@Valid InspectionItemRequest> items
 ) {
+    public InspectionRequest {
+        items = items == null ? List.of() : List.copyOf(items);
+    }
 }

--- a/src/main/java/com/cmms11/inspection/InspectionResponse.java
+++ b/src/main/java/com/cmms11/inspection/InspectionResponse.java
@@ -2,6 +2,8 @@ package com.cmms11.inspection;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 이름: InspectionResponse
@@ -26,10 +28,23 @@ public record InspectionResponse(
     LocalDateTime createdAt,
     String createdBy,
     LocalDateTime updatedAt,
-    String updatedBy
+    String updatedBy,
+    List<InspectionItemResponse> items
 ) {
+    public InspectionResponse {
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+
     public static InspectionResponse from(Inspection inspection) {
+        return from(inspection, List.of());
+    }
+
+    public static InspectionResponse from(Inspection inspection, List<InspectionItem> itemEntities) {
         String inspectionId = inspection.getId() != null ? inspection.getId().getInspectionId() : null;
+        List<InspectionItemResponse> itemResponses = itemEntities
+            .stream()
+            .map(InspectionItemResponse::from)
+            .collect(Collectors.toList());
         return new InspectionResponse(
             inspectionId,
             inspection.getName(),
@@ -46,7 +61,8 @@ public record InspectionResponse(
             inspection.getCreatedAt(),
             inspection.getCreatedBy(),
             inspection.getUpdatedAt(),
-            inspection.getUpdatedBy()
+            inspection.getUpdatedBy(),
+            itemResponses
         );
     }
 }

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -61,3 +61,39 @@ CREATE TABLE IF NOT EXISTS plant_master (
   CONSTRAINT pk_plant_master PRIMARY KEY (company_id, plant_id)
 );
 
+CREATE TABLE IF NOT EXISTS inspection (
+  company_id CHAR(5) NOT NULL,
+  inspection_id CHAR(10) NOT NULL,
+  name VARCHAR(100),
+  plant_id CHAR(10),
+  job_id CHAR(5),
+  site_id CHAR(5),
+  dept_id CHAR(5),
+  member_id CHAR(5),
+  planned_date DATE,
+  actual_date DATE,
+  status CHAR(10),
+  file_group_id VARCHAR(100),
+  note VARCHAR(500),
+  created_at TIMESTAMP NULL,
+  created_by CHAR(10),
+  updated_at TIMESTAMP NULL,
+  updated_by CHAR(10),
+  CONSTRAINT pk_inspection PRIMARY KEY (company_id, inspection_id)
+);
+
+CREATE TABLE IF NOT EXISTS inspection_item (
+  company_id CHAR(5) NOT NULL,
+  inspection_id CHAR(10) NOT NULL,
+  line_no INTEGER NOT NULL,
+  name VARCHAR(100),
+  method VARCHAR(100),
+  min_val VARCHAR(50),
+  max_val VARCHAR(50),
+  std_val VARCHAR(50),
+  unit VARCHAR(50),
+  result_val VARCHAR(50),
+  note VARCHAR(500),
+  CONSTRAINT pk_inspection_item PRIMARY KEY (company_id, inspection_id, line_no)
+);
+

--- a/src/test/java/com/cmms11/inspection/InspectionServiceTest.java
+++ b/src/test/java/com/cmms11/inspection/InspectionServiceTest.java
@@ -1,0 +1,155 @@
+package com.cmms11.inspection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cmms11.common.seq.AutoNumberService;
+import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DataJpaTest
+@Import({InspectionService.class, AutoNumberService.class})
+class InspectionServiceTest {
+
+    @Autowired
+    private InspectionService inspectionService;
+
+    @Autowired
+    private InspectionRepository inspectionRepository;
+
+    @Autowired
+    private InspectionItemRepository inspectionItemRepository;
+
+    @BeforeEach
+    void setUpAuthentication() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                "tester",
+                "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            )
+        );
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createInspectionPersistsItems() {
+        InspectionRequest request = defaultRequest(List.of(sampleItemRequest("압력", "bar", "1.60")));
+
+        InspectionResponse response = inspectionService.create(request);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).unit()).isEqualTo("bar");
+        assertThat(response.items().get(0).resultVal()).isEqualTo("1.60");
+
+        List<InspectionItem> savedItems = inspectionItemRepository
+            .findByIdCompanyIdAndIdInspectionIdOrderByIdLineNo(
+                MemberUserDetailsService.DEFAULT_COMPANY,
+                response.inspectionId()
+            );
+        assertThat(savedItems).hasSize(1);
+        assertThat(savedItems.get(0).getUnit()).isEqualTo("bar");
+        assertThat(savedItems.get(0).getResultVal()).isEqualTo("1.60");
+        assertThat(savedItems.get(0).getId().getLineNo()).isEqualTo(1);
+    }
+
+    @Test
+    void updateInspectionReplacesItems() {
+        InspectionResponse created = inspectionService.create(
+            defaultRequest(List.of(sampleItemRequest("압력", "bar", "1.60")))
+        );
+
+        InspectionRequest updateRequest = defaultRequest(
+            List.of(
+                sampleItemRequest("온도", "℃", "35"),
+                sampleItemRequest("소음", "dB", "70")
+            )
+        );
+
+        InspectionResponse updated = inspectionService.update(created.inspectionId(), updateRequest);
+
+        assertThat(updated.items()).hasSize(2);
+        assertThat(updated.items().get(0).name()).isEqualTo("온도");
+        assertThat(updated.items().get(1).name()).isEqualTo("소음");
+
+        List<InspectionItem> savedItems = inspectionItemRepository
+            .findByIdCompanyIdAndIdInspectionIdOrderByIdLineNo(
+                MemberUserDetailsService.DEFAULT_COMPANY,
+                created.inspectionId()
+            );
+        assertThat(savedItems).hasSize(2);
+        assertThat(savedItems.get(0).getId().getLineNo()).isEqualTo(1);
+        assertThat(savedItems.get(1).getId().getLineNo()).isEqualTo(2);
+    }
+
+    @Test
+    void deleteInspectionRemovesItems() {
+        InspectionResponse created = inspectionService.create(
+            defaultRequest(List.of(sampleItemRequest("압력", "bar", "1.60")))
+        );
+
+        inspectionService.delete(created.inspectionId());
+
+        assertThat(
+            inspectionRepository.findByIdCompanyIdAndIdInspectionId(
+                MemberUserDetailsService.DEFAULT_COMPANY,
+                created.inspectionId()
+            )
+        )
+            .isEmpty();
+
+        List<InspectionItem> remainingItems = inspectionItemRepository
+            .findByIdCompanyIdAndIdInspectionIdOrderByIdLineNo(
+                MemberUserDetailsService.DEFAULT_COMPANY,
+                created.inspectionId()
+            );
+        assertThat(remainingItems).isEmpty();
+    }
+
+    @Test
+    void getInspectionIncludesItems() {
+        InspectionResponse created = inspectionService.create(
+            defaultRequest(List.of(sampleItemRequest("압력", "bar", "1.60")))
+        );
+
+        InspectionResponse fetched = inspectionService.get(created.inspectionId());
+
+        assertThat(fetched.items()).hasSize(1);
+        assertThat(fetched.items().get(0).name()).isEqualTo("압력");
+    }
+
+    private InspectionRequest defaultRequest(List<InspectionItemRequest> items) {
+        return new InspectionRequest(
+            null,
+            "예방점검",
+            "P0001",
+            "J0001",
+            "S0001",
+            "D0001",
+            "M0001",
+            LocalDate.of(2025, 8, 20),
+            LocalDate.of(2025, 8, 21),
+            "READY",
+            "FG0001",
+            "비고",
+            items
+        );
+    }
+
+    private InspectionItemRequest sampleItemRequest(String name, String unit, String resultVal) {
+        return new InspectionItemRequest(name, "방법", "1", "2", "1.5", unit, resultVal, "비고");
+    }
+}

--- a/src/test/java/com/cmms11/web/InspectionControllerTest.java
+++ b/src/test/java/com/cmms11/web/InspectionControllerTest.java
@@ -1,0 +1,168 @@
+package com.cmms11.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.config.SecurityConfig;
+import com.cmms11.inspection.InspectionItemRequest;
+import com.cmms11.inspection.InspectionItemResponse;
+import com.cmms11.inspection.InspectionRequest;
+import com.cmms11.inspection.InspectionResponse;
+import com.cmms11.inspection.InspectionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = InspectionController.class)
+@Import(SecurityConfig.class)
+class InspectionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private InspectionService inspectionService;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @WithMockUser
+    @Test
+    void listInspectionsReturnsPagedResult() throws Exception {
+        InspectionResponse response = sampleResponse(LocalDateTime.now());
+        when(inspectionService.list(anyString(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/inspections").param("q", "정기점검"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].inspectionId").value("I250101001"))
+            .andExpect(jsonPath("$.content[0].items").isArray());
+
+        verify(inspectionService).list(anyString(), any(Pageable.class));
+    }
+
+    @WithMockUser
+    @Test
+    void getInspectionReturnsSuccess() throws Exception {
+        InspectionResponse response = sampleResponse(LocalDateTime.now());
+        when(inspectionService.get("I250101001")).thenReturn(response);
+
+        mockMvc.perform(get("/api/inspections/{inspectionId}", "I250101001"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.inspectionId").value("I250101001"))
+            .andExpect(jsonPath("$.items[0].unit").value("bar"));
+
+        verify(inspectionService).get("I250101001");
+    }
+
+    @WithMockUser
+    @Test
+    void createInspectionReturnsCreatedResponse() throws Exception {
+        InspectionRequest request = sampleRequest();
+        InspectionResponse response = sampleResponse(LocalDateTime.now());
+        when(inspectionService.create(any(InspectionRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/inspections")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.inspectionId").value("I250101001"));
+
+        verify(inspectionService).create(any(InspectionRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void updateInspectionReturnsOkResponse() throws Exception {
+        InspectionRequest request = sampleRequest();
+        InspectionResponse response = sampleResponse(LocalDateTime.now());
+        when(inspectionService.update(anyString(), any(InspectionRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/inspections/{inspectionId}", "I250101001")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].name").value("압력"));
+
+        verify(inspectionService).update(anyString(), any(InspectionRequest.class));
+    }
+
+    @WithMockUser
+    @Test
+    void deleteInspectionReturnsNoContent() throws Exception {
+        doNothing().when(inspectionService).delete("I250101001");
+
+        mockMvc.perform(delete("/api/inspections/{inspectionId}", "I250101001").with(csrf()))
+            .andExpect(status().isNoContent());
+
+        verify(inspectionService).delete("I250101001");
+    }
+
+    private InspectionRequest sampleRequest() {
+        return new InspectionRequest(
+            null,
+            "정기점검",
+            "P0001",
+            "J0001",
+            "S0001",
+            "D0001",
+            "M0001",
+            LocalDate.of(2025, 1, 1),
+            LocalDate.of(2025, 1, 2),
+            "READY",
+            "FG0001",
+            "특이사항",
+            List.of(new InspectionItemRequest("압력", "방법", "1", "2", "1.5", "bar", "1.60", "비고"))
+        );
+    }
+
+    private InspectionResponse sampleResponse(LocalDateTime now) {
+        return new InspectionResponse(
+            "I250101001",
+            "정기점검",
+            "P0001",
+            "J0001",
+            "S0001",
+            "D0001",
+            "M0001",
+            LocalDate.of(2025, 1, 1),
+            LocalDate.of(2025, 1, 2),
+            "READY",
+            "FG0001",
+            "특이사항",
+            now,
+            "tester",
+            now,
+            "tester",
+            List.of(new InspectionItemResponse(1, "압력", "방법", "1", "2", "1.5", "bar", "1.60", "비고"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- document unit and result columns for inspection items and align the baseline schema
- add inspection item entity, repository, DTOs, and integrate CRUD handling into the inspection service and controller
- add service and controller level tests covering inspection item lifecycle behaviors

## Testing
- sh gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68cf7e975a4c8323beb686d7d7ce0ae2