### PR TITLE
feat: extract member auth service for me endpoint

### DIFF
--- a/src/main/java/com/cmms11/common/error/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/cmms11/common/error/GlobalRestExceptionHandler.java
@@ -31,6 +31,14 @@ public class GlobalRestExceptionHandler {
         return ResponseEntity.status(status).body(body);
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnauthorized(UnauthorizedException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        ApiErrorResponse body = ApiErrorResponse.of(status.value(), status.getReasonPhrase(), ex.getMessage(), request.getRequestURI());
+        log.warn("Unauthorized access on {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(status).body(body);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;

--- a/src/main/java/com/cmms11/common/error/UnauthorizedException.java
+++ b/src/main/java/com/cmms11/common/error/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.cmms11.common.error;
+
+/**
+ * 인증이 필요한 요청에서 인증 정보가 없거나 유효하지 않을 때 발생시키는 예외.
+ */
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cmms11/domain/member/MemberAuthResponse.java
+++ b/src/main/java/com/cmms11/domain/member/MemberAuthResponse.java
@@ -1,0 +1,32 @@
+package com.cmms11.domain.member;
+
+import java.util.List;
+
+/**
+ * 인증된 사용자의 최소 정보를 응답하기 위한 DTO.
+ */
+public record MemberAuthResponse(
+    String memberId,
+    String companyId,
+    List<String> roles,
+    String name,
+    String deptId,
+    String email
+) {
+
+    public MemberAuthResponse {
+        roles = roles == null ? List.of() : List.copyOf(roles);
+    }
+
+    public static MemberAuthResponse of(String memberId, String companyId, List<String> roles, Member member) {
+        String resolvedName = null;
+        String resolvedDeptId = null;
+        String resolvedEmail = null;
+        if (member != null) {
+            resolvedName = member.getName();
+            resolvedDeptId = member.getDeptId();
+            resolvedEmail = member.getEmail();
+        }
+        return new MemberAuthResponse(memberId, companyId, roles, resolvedName, resolvedDeptId, resolvedEmail);
+    }
+}

--- a/src/main/java/com/cmms11/domain/member/MemberAuthService.java
+++ b/src/main/java/com/cmms11/domain/member/MemberAuthService.java
@@ -1,0 +1,42 @@
+package com.cmms11.domain.member;
+
+import com.cmms11.common.error.UnauthorizedException;
+import com.cmms11.security.MemberUserDetailsService;
+import java.util.List;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberAuthService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberAuthService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public MemberAuthResponse getAuthenticatedMember(Authentication authentication) {
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            throw new UnauthorizedException("Authentication is required");
+        }
+
+        String memberId = authentication.getName();
+        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
+
+        Member member = memberRepository
+                .findByIdCompanyIdAndIdMemberId(companyId, memberId)
+                .orElse(null);
+
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        return MemberAuthResponse.of(memberId, companyId, roles, member);
+    }
+}

--- a/src/main/java/com/cmms11/web/AuthController.java
+++ b/src/main/java/com/cmms11/web/AuthController.java
@@ -1,59 +1,25 @@
 package com.cmms11.web;
 
-import com.cmms11.domain.member.Member;
-import com.cmms11.domain.member.MemberRepository;
-import com.cmms11.security.MemberUserDetailsService;
-import org.springframework.http.ResponseEntity;
+import com.cmms11.domain.member.MemberAuthResponse;
+import com.cmms11.domain.member.MemberAuthService;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final MemberRepository memberRepository;
+    private final MemberAuthService memberAuthService;
 
-    public AuthController(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
+    public AuthController(MemberAuthService memberAuthService) {
+        this.memberAuthService = memberAuthService;
     }
 
     @GetMapping("/me")
-    public ResponseEntity<?> me(Authentication authentication) {
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return ResponseEntity.status(401).build();
-        }
-
-        String memberId = authentication.getName();
-        String companyId = MemberUserDetailsService.DEFAULT_COMPANY;
-
-        Member member = memberRepository
-                .findByIdCompanyIdAndIdMemberId(companyId, memberId)
-                .orElse(null);
-
-        List<String> roles = authentication.getAuthorities()
-                .stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.toList());
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("memberId", memberId);
-        body.put("companyId", companyId);
-        body.put("roles", roles);
-        if (member != null) {
-            body.put("name", member.getName());
-            body.put("deptId", member.getDeptId());
-            body.put("email", member.getEmail());
-        }
-
-        return ResponseEntity.ok(body);
+    public MemberAuthResponse me(Authentication authentication) {
+        return memberAuthService.getAuthenticatedMember(authentication);
     }
 }
 

--- a/src/test/java/com/cmms11/domain/member/MemberAuthServiceTest.java
+++ b/src/test/java/com/cmms11/domain/member/MemberAuthServiceTest.java
@@ -1,0 +1,77 @@
+package com.cmms11.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.cmms11.common.error.UnauthorizedException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@ExtendWith(MockitoExtension.class)
+class MemberAuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private MemberAuthService memberAuthService;
+
+    @BeforeEach
+    void setUp() {
+        memberAuthService = new MemberAuthService(memberRepository);
+    }
+
+    @Test
+    void getAuthenticatedMemberReturnsResponseWhenAuthenticated() {
+        MemberId id = new MemberId("C0001", "tester");
+        Member member = new Member();
+        member.setId(id);
+        member.setName("홍길동");
+        member.setDeptId("D100");
+        member.setEmail("tester@example.com");
+
+        when(memberRepository.findByIdCompanyIdAndIdMemberId(eq("C0001"), eq("tester")))
+                .thenReturn(Optional.of(member));
+
+        UsernamePasswordAuthenticationToken authentication = UsernamePasswordAuthenticationToken.authenticated(
+                "tester",
+                "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        MemberAuthResponse response = memberAuthService.getAuthenticatedMember(authentication);
+
+        assertThat(response.memberId()).isEqualTo("tester");
+        assertThat(response.companyId()).isEqualTo("C0001");
+        assertThat(response.roles()).containsExactly("ROLE_USER");
+        assertThat(response.name()).isEqualTo("홍길동");
+        assertThat(response.deptId()).isEqualTo("D100");
+        assertThat(response.email()).isEqualTo("tester@example.com");
+    }
+
+    @Test
+    void getAuthenticatedMemberThrowsWhenAuthenticationInvalid() {
+        AnonymousAuthenticationToken anonymousAuthenticationToken = new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+        );
+
+        assertThrows(UnauthorizedException.class,
+                () -> memberAuthService.getAuthenticatedMember(anonymousAuthenticationToken));
+    }
+
+    @Test
+    void getAuthenticatedMemberThrowsWhenAuthenticationMissing() {
+        assertThrows(UnauthorizedException.class, () -> memberAuthService.getAuthenticatedMember(null));
+    }
+}

--- a/src/test/java/com/cmms11/web/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/cmms11/web/AuthControllerIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.cmms11.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.domain.member.Member;
+import com.cmms11.domain.member.MemberId;
+import com.cmms11.domain.member.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void meEndpointReturnsMemberInformation() throws Exception {
+        MemberId id = new MemberId("C0001", "admin");
+        Member member = new Member();
+        member.setId(id);
+        member.setName("관리자");
+        member.setDeptId("D001");
+        member.setEmail("admin@example.com");
+        memberRepository.save(member);
+
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberId").value("admin"))
+                .andExpect(jsonPath("$.companyId").value("C0001"))
+                .andExpect(jsonPath("$.name").value("관리자"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_ADMIN"));
+    }
+}

--- a/src/test/java/com/cmms11/web/AuthControllerTest.java
+++ b/src/test/java/com/cmms11/web/AuthControllerTest.java
@@ -1,0 +1,72 @@
+package com.cmms11.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cmms11.common.error.UnauthorizedException;
+import com.cmms11.config.SecurityConfig;
+import com.cmms11.domain.member.MemberAuthResponse;
+import com.cmms11.domain.member.MemberAuthService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(SecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberAuthService memberAuthService;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @Test
+    @WithMockUser(username = "tester", roles = {"USER"})
+    void meReturnsAuthenticatedMemberInformation() throws Exception {
+        MemberAuthResponse response = new MemberAuthResponse(
+                "tester",
+                "C0001",
+                List.of("ROLE_USER"),
+                "홍길동",
+                "D100",
+                "tester@example.com"
+        );
+
+        when(memberAuthService.getAuthenticatedMember(any(Authentication.class))).thenReturn(response);
+
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberId").value("tester"))
+                .andExpect(jsonPath("$.companyId").value("C0001"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.name").value("홍길동"))
+                .andExpect(jsonPath("$.deptId").value("D100"))
+                .andExpect(jsonPath("$.email").value("tester@example.com"));
+    }
+
+    @Test
+    @WithMockUser
+    void meReturnsUnauthorizedWhenServiceThrowsException() throws Exception {
+        when(memberAuthService.getAuthenticatedMember(any(Authentication.class)))
+                .thenThrow(new UnauthorizedException("Authentication is required"));
+
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Authentication is required"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated MemberAuthService and DTO to encapsulate /api/auth/me lookups
- route AuthController through the new service and centralize unauthorized handling in the global error handler
- cover the endpoint with new unit and integration tests

## Testing
- `gradle test` *(fails: unable to download Spring Boot Gradle plugin because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7e983b1c832399738fe12de07b89