### PR TITLE
feat: support company view routes

### DIFF
--- a/src/main/java/com/cmms11/web/CompanyController.java
+++ b/src/main/java/com/cmms11/web/CompanyController.java
@@ -8,17 +8,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 
 /**
@@ -26,10 +25,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 회사 기준정보 API 컨트롤러.
+ * 프로그램 개요: 회사 기준정보 화면 및 API 엔드포인트를 제공하는 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/domain/companies")
+@Controller
 public class CompanyController {
 
     private final CompanyService service;
@@ -38,26 +36,50 @@ public class CompanyController {
         this.service = service;
     }
 
-    @GetMapping
-    public Page<CompanyResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+    @GetMapping("/domain/company")
+    public String listView(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<CompanyResponse> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/company/list";
+    }
 
+    @GetMapping("/domain/company/new")
+    public String newCompanyForm(Model model) {
+        model.addAttribute("company", new CompanyResponse(null, null, null, null, null, null, null, null));
+        model.addAttribute("isNew", true);
+        return "domain/company/form";
+    }
+
+    @GetMapping("/domain/company/{companyId}")
+    public String editCompanyForm(@PathVariable String companyId, Model model) {
+        CompanyResponse company = service.get(companyId);
+        model.addAttribute("company", company);
+        model.addAttribute("isNew", false);
+        return "domain/company/form";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/companies")
+    public Page<CompanyResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{companyId}")
+    @ResponseBody
+    @GetMapping("/api/domain/companies/{companyId}")
     public ResponseEntity<CompanyResponse> get(@PathVariable String companyId) {
         return ResponseEntity.ok(service.get(companyId));
-
     }
 
-    @PostMapping
+    @ResponseBody
+    @PostMapping("/api/domain/companies")
     public ResponseEntity<CompanyResponse> create(@Valid @RequestBody CompanyRequest request) {
-
         CompanyResponse response = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{companyId}")
+    @ResponseBody
+    @PutMapping("/api/domain/companies/{companyId}")
     public ResponseEntity<CompanyResponse> update(
         @PathVariable String companyId,
         @Valid @RequestBody CompanyRequest request
@@ -66,7 +88,8 @@ public class CompanyController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{companyId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/companies/{companyId}")
     public ResponseEntity<Void> delete(@PathVariable String companyId) {
         service.delete(companyId);
         return ResponseEntity.noContent().build();

--- a/src/test/java/com/cmms11/web/CompanyControllerViewTest.java
+++ b/src/test/java/com/cmms11/web/CompanyControllerViewTest.java
@@ -1,0 +1,99 @@
+package com.cmms11.web;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.cmms11.config.SecurityConfig;
+import com.cmms11.domain.company.CompanyResponse;
+import com.cmms11.domain.company.CompanyService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 이름: CompanyControllerViewTest
+ * 작성자: codex
+ * 작성일: 2025-08-20
+ * 수정일:
+ * 프로그램 개요: 회사 화면 라우트를 검증하는 MVC 테스트.
+ */
+@WebMvcTest(controllers = CompanyController.class)
+@Import(SecurityConfig.class)
+class CompanyControllerViewTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CompanyService companyService;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @WithMockUser
+    @Test
+    void listViewRendersPageWithSearchKeyword() throws Exception {
+        LocalDateTime now = LocalDateTime.of(2024, 1, 1, 9, 0);
+        CompanyResponse response = new CompanyResponse("C0001", "샘플회사", "메모", "N", now, "tester", now, "tester");
+        Page<CompanyResponse> page = new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1);
+        when(companyService.list(eq("샘플"), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/domain/company").param("q", "샘플"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("domain/company/list"))
+            .andExpect(model().attribute("page", sameInstance(page)))
+            .andExpect(model().attribute("keyword", "샘플"));
+
+        verify(companyService).list(eq("샘플"), any(Pageable.class));
+    }
+
+    @WithMockUser
+    @Test
+    void newFormProvidesDefaultModelAttributes() throws Exception {
+        mockMvc.perform(get("/domain/company/new"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("domain/company/form"))
+            .andExpect(model().attribute("isNew", true))
+            .andExpect(model().attributeExists("company"));
+
+        verify(companyService, never()).get(anyString());
+        verify(companyService, never()).list(anyString(), any(Pageable.class));
+    }
+
+    @WithMockUser
+    @Test
+    void editFormLoadsCompanyFromService() throws Exception {
+        LocalDateTime now = LocalDateTime.of(2024, 1, 1, 9, 0);
+        CompanyResponse response = new CompanyResponse("C0001", "샘플회사", "메모", "N", now, "tester", now, "tester");
+        when(companyService.get("C0001")).thenReturn(response);
+
+        mockMvc.perform(get("/domain/company/{companyId}", "C0001"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("domain/company/form"))
+            .andExpect(model().attribute("company", response))
+            .andExpect(model().attribute("isNew", false));
+
+        verify(companyService).get("C0001");
+    }
+}
+


### PR DESCRIPTION
## Summary
- convert `CompanyController` into a unified MVC controller with HTML view handlers for `/domain/company` pages
- keep the existing service-backed REST endpoints under `/api/domain/companies` by annotating them with `@ResponseBody`
- add MVC tests exercising the HTML routes through `CompanyController`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `gradle test` *(fails: Spring Boot Gradle plugin could not be resolved without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdfb47a9083239f96a420c4bfe506