### PR TITLE
Add web controllers for domain and code modules

### DIFF
--- a/src/main/java/com/cmms11/domain/member/MemberService.java
+++ b/src/main/java/com/cmms11/domain/member/MemberService.java
@@ -1,14 +1,16 @@
 package com.cmms11.domain.member;
 
-import com.cmms11.common.error.NotFoundException;
-import com.cmms11.security.MemberUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
+import com.cmms11.common.error.NotFoundException;
+import com.cmms11.security.MemberUserDetailsService;
 
 @Service
 @Transactional
@@ -46,8 +48,60 @@ public class MemberService {
         if (rawPassword != null && !rawPassword.isBlank()) {
             member.setPasswordHash(passwordEncoder.encode(rawPassword));
         }
-        member.setCreatedAt(LocalDateTime.now());
-        member.setCreatedBy(actor != null ? actor : "system");
+        LocalDateTime now = LocalDateTime.now();
+        String actorId = resolveActor(actor);
+        member.setCreatedAt(now);
+        member.setCreatedBy(actorId);
+        member.setUpdatedAt(now);
+        member.setUpdatedBy(actorId);
         return repository.save(member);
+    }
+
+    public Member update(Member member, String rawPassword, String actor) {
+        if (member.getId() == null || member.getId().getMemberId() == null) {
+            throw new IllegalArgumentException("member.id (memberId) is required");
+        }
+        Member existing = repository
+            .findByIdCompanyIdAndIdMemberId(MemberUserDetailsService.DEFAULT_COMPANY, member.getId().getMemberId())
+            .orElseThrow(() -> new NotFoundException("Member not found: " + member.getId().getMemberId()));
+
+        existing.setName(member.getName());
+        existing.setDeptId(member.getDeptId());
+        existing.setEmail(member.getEmail());
+        existing.setPhone(member.getPhone());
+        existing.setNote(member.getNote());
+        Optional.ofNullable(member.getDeleteMark()).ifPresent(existing::setDeleteMark);
+        if (rawPassword != null && !rawPassword.isBlank()) {
+            existing.setPasswordHash(passwordEncoder.encode(rawPassword));
+        }
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(resolveActor(actor));
+        return repository.save(existing);
+    }
+
+    public void delete(String memberId, String actor) {
+        Member existing = repository
+            .findByIdCompanyIdAndIdMemberId(MemberUserDetailsService.DEFAULT_COMPANY, memberId)
+            .orElseThrow(() -> new NotFoundException("Member not found: " + memberId));
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(resolveActor(actor));
+        repository.save(existing);
+    }
+
+    private String resolveActor(String actor) {
+        if (actor != null && !actor.isBlank()) {
+            return actor;
+        }
+        return currentMemberId();
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
     }
 }

--- a/src/main/java/com/cmms11/web/CodeController.java
+++ b/src/main/java/com/cmms11/web/CodeController.java
@@ -6,29 +6,36 @@ import com.cmms11.code.CodeService;
 import com.cmms11.code.CodeTypeRequest;
 import com.cmms11.code.CodeTypeResponse;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 이름: CodeController
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 공통 코드 타입 및 항목을 관리하는 REST 컨트롤러.
+ * 프로그램 개요: 공통 코드 타입 및 항목을 관리하는 웹/REST 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/codes")
+@Controller
 public class CodeController {
 
     private final CodeService service;
@@ -37,23 +44,126 @@ public class CodeController {
         this.service = service;
     }
 
-    @GetMapping("/types")
+    @GetMapping("/code/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<CodeTypeResponse> page = service.listTypes(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "code/list";
+    }
+
+    @GetMapping("/code/form")
+    public String newForm(Model model) {
+        model.addAttribute("codeType", new CodeTypeResponse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+        model.addAttribute("items", List.of());
+        model.addAttribute("form", new CodeForm());
+        model.addAttribute("isNew", true);
+        return "code/form";
+    }
+
+    @GetMapping("/code/edit/{codeType}")
+    public String editForm(@PathVariable String codeType, Model model) {
+        CodeTypeResponse type = service.getType(codeType);
+        List<CodeItemResponse> items = service.listItems(codeType, null, Pageable.unpaged()).getContent();
+        CodeForm form = new CodeForm();
+        form.setCodeType(type.codeType());
+        form.setName(type.name());
+        form.setNote(type.note());
+        form.setItems(items.stream().map(CodeItemForm::from).collect(Collectors.toCollection(ArrayList::new)));
+        model.addAttribute("codeType", type);
+        model.addAttribute("items", items);
+        model.addAttribute("form", form);
+        model.addAttribute("isNew", false);
+        return "code/form";
+    }
+
+    @PostMapping("/code/save")
+    public String saveForm(@ModelAttribute CodeForm form, @RequestParam(required = false) String isNew) {
+        CodeTypeRequest typeRequest = new CodeTypeRequest(form.getCodeType(), form.getName(), form.getNote());
+        boolean create = "true".equals(isNew);
+        if (create) {
+            service.createType(typeRequest);
+        } else {
+            service.updateType(form.getCodeType(), typeRequest);
+        }
+
+        List<CodeItemForm> submittedItems = Optional.ofNullable(form.getItems()).orElseGet(ArrayList::new);
+        if (create) {
+            for (CodeItemForm item : submittedItems) {
+                if (item.isBlank()) {
+                    continue;
+                }
+                CodeItemRequest request = new CodeItemRequest(form.getCodeType(), item.getCode(), item.getName(), item.getNote());
+                service.createItem(request);
+            }
+        } else {
+            Map<String, CodeItemResponse> existing = service
+                .listItems(form.getCodeType(), null, Pageable.unpaged())
+                .getContent()
+                .stream()
+                .collect(Collectors.toMap(CodeItemResponse::code, it -> it, (a, b) -> a, HashMap::new));
+
+            for (CodeItemForm item : submittedItems) {
+                if (item.isBlank()) {
+                    continue;
+                }
+                CodeItemRequest request = new CodeItemRequest(form.getCodeType(), item.getCode(), item.getName(), item.getNote());
+                if (existing.containsKey(item.getCode())) {
+                    service.updateItem(form.getCodeType(), item.getCode(), request);
+                    existing.remove(item.getCode());
+                } else {
+                    service.createItem(request);
+                }
+            }
+
+            for (String code : existing.keySet()) {
+                service.deleteItem(form.getCodeType(), code);
+            }
+        }
+
+        return "redirect:/code/list";
+    }
+
+    @PostMapping("/code/delete/{codeType}")
+    public String deleteForm(@PathVariable String codeType) {
+        List<CodeItemResponse> items = service.listItems(codeType, null, Pageable.unpaged()).getContent();
+        for (CodeItemResponse item : items) {
+            service.deleteItem(codeType, item.code());
+        }
+        service.deleteType(codeType);
+        return "redirect:/code/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/codes/types")
     public Page<CodeTypeResponse> listTypes(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.listTypes(q, pageable);
     }
 
-    @GetMapping("/types/{codeType}")
+    @ResponseBody
+    @GetMapping("/api/codes/types/{codeType}")
     public ResponseEntity<CodeTypeResponse> getType(@PathVariable String codeType) {
         return ResponseEntity.ok(service.getType(codeType));
     }
 
-    @PostMapping("/types")
+    @ResponseBody
+    @PostMapping("/api/codes/types")
     public ResponseEntity<CodeTypeResponse> createType(@Valid @RequestBody CodeTypeRequest request) {
         CodeTypeResponse response = service.createType(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/types/{codeType}")
+    @ResponseBody
+    @PutMapping("/api/codes/types/{codeType}")
     public ResponseEntity<CodeTypeResponse> updateType(
         @PathVariable String codeType,
         @Valid @RequestBody CodeTypeRequest request
@@ -62,13 +172,15 @@ public class CodeController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/types/{codeType}")
+    @ResponseBody
+    @DeleteMapping("/api/codes/types/{codeType}")
     public ResponseEntity<Void> deleteType(@PathVariable String codeType) {
         service.deleteType(codeType);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/types/{codeType}/items")
+    @ResponseBody
+    @GetMapping("/api/codes/types/{codeType}/items")
     public Page<CodeItemResponse> listItems(
         @PathVariable String codeType,
         @RequestParam(name = "q", required = false) String q,
@@ -77,12 +189,14 @@ public class CodeController {
         return service.listItems(codeType, q, pageable);
     }
 
-    @GetMapping("/types/{codeType}/items/{code}")
+    @ResponseBody
+    @GetMapping("/api/codes/types/{codeType}/items/{code}")
     public ResponseEntity<CodeItemResponse> getItem(@PathVariable String codeType, @PathVariable String code) {
         return ResponseEntity.ok(service.getItem(codeType, code));
     }
 
-    @PostMapping("/types/{codeType}/items")
+    @ResponseBody
+    @PostMapping("/api/codes/types/{codeType}/items")
     public ResponseEntity<CodeItemResponse> createItem(
         @PathVariable String codeType,
         @Valid @RequestBody CodeItemRequest request
@@ -92,7 +206,8 @@ public class CodeController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/types/{codeType}/items/{code}")
+    @ResponseBody
+    @PutMapping("/api/codes/types/{codeType}/items/{code}")
     public ResponseEntity<CodeItemResponse> updateItem(
         @PathVariable String codeType,
         @PathVariable String code,
@@ -103,10 +218,92 @@ public class CodeController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/types/{codeType}/items/{code}")
+    @ResponseBody
+    @DeleteMapping("/api/codes/types/{codeType}/items/{code}")
     public ResponseEntity<Void> deleteItem(@PathVariable String codeType, @PathVariable String code) {
         service.deleteItem(codeType, code);
         return ResponseEntity.noContent().build();
+    }
+
+    public static class CodeForm {
+        private String codeType;
+        private String name;
+        private String note;
+        private List<CodeItemForm> items = new ArrayList<>();
+
+        public String getCodeType() {
+            return codeType;
+        }
+
+        public void setCodeType(String codeType) {
+            this.codeType = codeType;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+
+        public List<CodeItemForm> getItems() {
+            return items;
+        }
+
+        public void setItems(List<CodeItemForm> items) {
+            this.items = items;
+        }
+    }
+
+    public static class CodeItemForm {
+        private String code;
+        private String name;
+        private String note;
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+
+        private boolean isBlank() {
+            return (code == null || code.isBlank()) || (name == null || name.isBlank());
+        }
+
+        private static CodeItemForm from(CodeItemResponse response) {
+            CodeItemForm form = new CodeItemForm();
+            form.setCode(response.code());
+            form.setName(response.name());
+            form.setNote(response.note());
+            return form;
+        }
     }
 }
 

--- a/src/main/java/com/cmms11/web/DeptController.java
+++ b/src/main/java/com/cmms11/web/DeptController.java
@@ -8,25 +8,26 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 이름: DeptController
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 부서 기준정보 API 컨트롤러.
+ * 프로그램 개요: 부서 기준정보 웹 화면 및 API 엔드포인트를 제공하는 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/domain/depts")
+@Controller
 public class DeptController {
 
     private final DeptService service;
@@ -35,24 +36,75 @@ public class DeptController {
         this.service = service;
     }
 
-    @GetMapping
-    public Page<DeptResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
+    @GetMapping("/domain/dept/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<DeptResponse> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/dept/list";
+    }
 
+    @GetMapping("/domain/dept/form")
+    public String newForm(Model model) {
+        model.addAttribute("dept", new DeptResponse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+        model.addAttribute("isNew", true);
+        return "domain/dept/form";
+    }
+
+    @GetMapping("/domain/dept/edit/{deptId}")
+    public String editForm(@PathVariable String deptId, Model model) {
+        DeptResponse dept = service.get(deptId);
+        model.addAttribute("dept", dept);
+        model.addAttribute("isNew", false);
+        return "domain/dept/form";
+    }
+
+    @PostMapping("/domain/dept/save")
+    public String saveForm(@ModelAttribute DeptRequest request, @RequestParam(required = false) String isNew) {
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(request.deptId(), request);
+        }
+        return "redirect:/domain/dept/list";
+    }
+
+    @PostMapping("/domain/dept/delete/{deptId}")
+    public String deleteForm(@PathVariable String deptId) {
+        service.delete(deptId);
+        return "redirect:/domain/dept/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/depts")
+    public Page<DeptResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{deptId}")
+    @ResponseBody
+    @GetMapping("/api/domain/depts/{deptId}")
     public ResponseEntity<DeptResponse> get(@PathVariable String deptId) {
         return ResponseEntity.ok(service.get(deptId));
     }
 
-    @PostMapping
+    @ResponseBody
+    @PostMapping("/api/domain/depts")
     public ResponseEntity<DeptResponse> create(@Valid @RequestBody DeptRequest request) {
         DeptResponse response = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{deptId}")
+    @ResponseBody
+    @PutMapping("/api/domain/depts/{deptId}")
     public ResponseEntity<DeptResponse> update(
         @PathVariable String deptId,
         @Valid @RequestBody DeptRequest request
@@ -61,7 +113,8 @@ public class DeptController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{deptId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/depts/{deptId}")
     public ResponseEntity<Void> delete(@PathVariable String deptId) {
         service.delete(deptId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/cmms11/web/FuncController.java
+++ b/src/main/java/com/cmms11/web/FuncController.java
@@ -8,25 +8,26 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 이름: FuncController
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 기능위치 기준정보 API 컨트롤러.
+ * 프로그램 개요: 기능위치 기준정보 웹 화면 및 API 엔드포인트를 제공하는 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/domain/funcs")
+@Controller
 public class FuncController {
 
     private final FuncService service;
@@ -35,27 +36,75 @@ public class FuncController {
         this.service = service;
     }
 
-    @GetMapping
+    @GetMapping("/domain/func/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<FuncResponse> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/func/list";
+    }
 
+    @GetMapping("/domain/func/form")
+    public String newForm(Model model) {
+        model.addAttribute("func", new FuncResponse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+        model.addAttribute("isNew", true);
+        return "domain/func/form";
+    }
+
+    @GetMapping("/domain/func/edit/{funcId}")
+    public String editForm(@PathVariable String funcId, Model model) {
+        FuncResponse func = service.get(funcId);
+        model.addAttribute("func", func);
+        model.addAttribute("isNew", false);
+        return "domain/func/form";
+    }
+
+    @PostMapping("/domain/func/save")
+    public String saveForm(@ModelAttribute FuncRequest request, @RequestParam(required = false) String isNew) {
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(request.funcId(), request);
+        }
+        return "redirect:/domain/func/list";
+    }
+
+    @PostMapping("/domain/func/delete/{funcId}")
+    public String deleteForm(@PathVariable String funcId) {
+        service.delete(funcId);
+        return "redirect:/domain/func/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/funcs")
     public Page<FuncResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{funcId}")
-
+    @ResponseBody
+    @GetMapping("/api/domain/funcs/{funcId}")
     public ResponseEntity<FuncResponse> get(@PathVariable String funcId) {
-
         return ResponseEntity.ok(service.get(funcId));
     }
 
-    @PostMapping
-
+    @ResponseBody
+    @PostMapping("/api/domain/funcs")
     public ResponseEntity<FuncResponse> create(@Valid @RequestBody FuncRequest request) {
         FuncResponse response = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{funcId}")
+    @ResponseBody
+    @PutMapping("/api/domain/funcs/{funcId}")
     public ResponseEntity<FuncResponse> update(
         @PathVariable String funcId,
         @Valid @RequestBody FuncRequest request
@@ -64,10 +113,10 @@ public class FuncController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{funcId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/funcs/{funcId}")
     public ResponseEntity<Void> delete(@PathVariable String funcId) {
         service.delete(funcId);
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/java/com/cmms11/web/MemberController.java
+++ b/src/main/java/com/cmms11/web/MemberController.java
@@ -3,15 +3,24 @@ package com.cmms11.web;
 import com.cmms11.domain.member.Member;
 import com.cmms11.domain.member.MemberId;
 import com.cmms11.domain.member.MemberService;
+import com.cmms11.security.MemberUserDetailsService;
 import jakarta.validation.Valid;
+import java.util.Objects;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
-@RestController
-@RequestMapping("/api/members")
+@Controller
 public class MemberController {
     private final MemberService service;
 
@@ -19,17 +28,71 @@ public class MemberController {
         this.service = service;
     }
 
-    @GetMapping
+    @GetMapping("/domain/member/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<Member> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/member/list";
+    }
+
+    @GetMapping("/domain/member/form")
+    public String newForm(Model model) {
+        MemberForm form = new MemberForm();
+        form.setDeleteMark("N");
+        model.addAttribute("member", form);
+        model.addAttribute("isNew", true);
+        return "domain/member/form";
+    }
+
+    @GetMapping("/domain/member/edit/{memberId}")
+    public String editForm(@PathVariable String memberId, Model model) {
+        Member member = service.get(memberId);
+        MemberForm form = toForm(member);
+        model.addAttribute("member", form);
+        model.addAttribute("isNew", false);
+        return "domain/member/form";
+    }
+
+    @PostMapping("/domain/member/save")
+    public String saveForm(@ModelAttribute MemberForm form, @RequestParam(required = false) String isNew) {
+        Member member = new Member();
+        member.setId(new MemberId(MemberUserDetailsService.DEFAULT_COMPANY, form.getMemberId()));
+        member.setName(form.getName());
+        member.setDeptId(form.getDeptId());
+        member.setEmail(form.getEmail());
+        member.setPhone(form.getPhone());
+        member.setNote(form.getNote());
+        member.setDeleteMark(Objects.requireNonNullElse(form.getDeleteMark(), "N"));
+
+        if ("true".equals(isNew)) {
+            service.create(member, form.getPassword(), null);
+        } else {
+            service.update(member, form.getPassword(), null);
+        }
+        return "redirect:/domain/member/list";
+    }
+
+    @PostMapping("/domain/member/delete/{memberId}")
+    public String deleteForm(@PathVariable String memberId) {
+        service.delete(memberId, null);
+        return "redirect:/domain/member/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/members")
     public Page<Member> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{memberId}")
+    @ResponseBody
+    @GetMapping("/api/members/{memberId}")
     public ResponseEntity<Member> get(@PathVariable String memberId) {
         return ResponseEntity.ok(service.get(memberId));
     }
 
-    @PostMapping
+    @ResponseBody
+    @PostMapping("/api/members")
     public ResponseEntity<Member> create(@Valid @RequestBody MemberCreateRequest req) {
         Member member = new Member();
         member.setId(new MemberId(null, req.member_id));
@@ -38,9 +101,98 @@ public class MemberController {
         member.setEmail(req.email);
         member.setPhone(req.phone);
         member.setNote(req.note);
-        if (req.delete_mark != null) member.setDeleteMark(req.delete_mark);
+        if (req.delete_mark != null) {
+            member.setDeleteMark(req.delete_mark);
+        }
         Member saved = service.create(member, req.password, req.actor);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    private MemberForm toForm(Member member) {
+        MemberForm form = new MemberForm();
+        form.setMemberId(member.getId() != null ? member.getId().getMemberId() : null);
+        form.setName(member.getName());
+        form.setDeptId(member.getDeptId());
+        form.setEmail(member.getEmail());
+        form.setPhone(member.getPhone());
+        form.setNote(member.getNote());
+        form.setDeleteMark(member.getDeleteMark());
+        return form;
+    }
+
+    public static class MemberForm {
+        private String memberId;
+        private String name;
+        private String deptId;
+        private String email;
+        private String phone;
+        private String note;
+        private String password;
+        private String deleteMark = "N";
+
+        public String getMemberId() {
+            return memberId;
+        }
+
+        public void setMemberId(String memberId) {
+            this.memberId = memberId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDeptId() {
+            return deptId;
+        }
+
+        public void setDeptId(String deptId) {
+            this.deptId = deptId;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public void setPhone(String phone) {
+            this.phone = phone;
+        }
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public String getDeleteMark() {
+            return deleteMark;
+        }
+
+        public void setDeleteMark(String deleteMark) {
+            this.deleteMark = deleteMark;
+        }
     }
 
     public static class MemberCreateRequest {

--- a/src/main/java/com/cmms11/web/RoleController.java
+++ b/src/main/java/com/cmms11/web/RoleController.java
@@ -1,40 +1,84 @@
 package com.cmms11.web;
 
 import java.util.Map;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
-@RestController
-@RequestMapping("/api/domain/roles")
+@Controller
 public class RoleController {
 
-    @GetMapping
+    @GetMapping("/domain/role/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        model.addAttribute("page", Page.empty());
+        model.addAttribute("keyword", q);
+        return "domain/role/list";
+    }
+
+    @GetMapping("/domain/role/form")
+    public String newForm(Model model) {
+        model.addAttribute("roleId", null);
+        model.addAttribute("isNew", true);
+        return "domain/role/form";
+    }
+
+    @GetMapping("/domain/role/edit/{roleId}")
+    public String editForm(@PathVariable String roleId, Model model) {
+        model.addAttribute("roleId", roleId);
+        model.addAttribute("isNew", false);
+        return "domain/role/form";
+    }
+
+    @PostMapping("/domain/role/save")
+    public String saveForm() {
+        throw new UnsupportedOperationException("Role management is not implemented yet");
+    }
+
+    @PostMapping("/domain/role/delete/{roleId}")
+    public String deleteForm(@PathVariable String roleId) {
+        throw new UnsupportedOperationException("Role management is not implemented yet");
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/roles")
     public ResponseEntity<?> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
             .body(Map.of("message", "list roles not implemented"));
     }
 
-    @GetMapping("/{roleId}")
+    @ResponseBody
+    @GetMapping("/api/domain/roles/{roleId}")
     public ResponseEntity<?> get(@PathVariable("roleId") String roleId) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
             .body(Map.of("message", "get role not implemented"));
     }
 
-    @PostMapping
+    @ResponseBody
+    @PostMapping("/api/domain/roles")
     public ResponseEntity<?> create(@RequestBody Map<String, Object> body) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
             .body(Map.of("message", "create role not implemented"));
     }
 
-    @PutMapping("/{roleId}")
+    @ResponseBody
+    @PutMapping("/api/domain/roles/{roleId}")
     public ResponseEntity<?> update(@PathVariable("roleId") String roleId, @RequestBody Map<String, Object> body) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
             .body(Map.of("message", "update role not implemented"));
     }
 
-    @DeleteMapping("/{roleId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/roles/{roleId}")
     public ResponseEntity<?> delete(@PathVariable("roleId") String roleId) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
             .body(Map.of("message", "delete role not implemented"));

--- a/src/main/java/com/cmms11/web/SiteController.java
+++ b/src/main/java/com/cmms11/web/SiteController.java
@@ -1,34 +1,33 @@
 package com.cmms11.web;
 
-
 import com.cmms11.domain.site.SiteRequest;
 import com.cmms11.domain.site.SiteResponse;
 import com.cmms11.domain.site.SiteService;
-
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 이름: SiteController
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 사업장 기준정보 API 컨트롤러.
+ * 프로그램 개요: 사업장 기준정보 웹 화면 및 API 엔드포인트를 제공하는 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/domain/sites")
+@Controller
 public class SiteController {
 
     private final SiteService service;
@@ -37,23 +36,75 @@ public class SiteController {
         this.service = service;
     }
 
-    @GetMapping
+    @GetMapping("/domain/site/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<SiteResponse> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/site/list";
+    }
+
+    @GetMapping("/domain/site/form")
+    public String newForm(Model model) {
+        model.addAttribute("site", new SiteResponse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+        model.addAttribute("isNew", true);
+        return "domain/site/form";
+    }
+
+    @GetMapping("/domain/site/edit/{siteId}")
+    public String editForm(@PathVariable String siteId, Model model) {
+        SiteResponse site = service.get(siteId);
+        model.addAttribute("site", site);
+        model.addAttribute("isNew", false);
+        return "domain/site/form";
+    }
+
+    @PostMapping("/domain/site/save")
+    public String saveForm(@ModelAttribute SiteRequest request, @RequestParam(required = false) String isNew) {
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(request.siteId(), request);
+        }
+        return "redirect:/domain/site/list";
+    }
+
+    @PostMapping("/domain/site/delete/{siteId}")
+    public String deleteForm(@PathVariable String siteId) {
+        service.delete(siteId);
+        return "redirect:/domain/site/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/sites")
     public Page<SiteResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{siteId}")
+    @ResponseBody
+    @GetMapping("/api/domain/sites/{siteId}")
     public ResponseEntity<SiteResponse> get(@PathVariable String siteId) {
         return ResponseEntity.ok(service.get(siteId));
     }
 
-    @PostMapping
+    @ResponseBody
+    @PostMapping("/api/domain/sites")
     public ResponseEntity<SiteResponse> create(@Valid @RequestBody SiteRequest request) {
         SiteResponse response = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{siteId}")
+    @ResponseBody
+    @PutMapping("/api/domain/sites/{siteId}")
     public ResponseEntity<SiteResponse> update(
         @PathVariable String siteId,
         @Valid @RequestBody SiteRequest request
@@ -62,7 +113,8 @@ public class SiteController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{siteId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/sites/{siteId}")
     public ResponseEntity<Void> delete(@PathVariable String siteId) {
         service.delete(siteId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/cmms11/web/StorageController.java
+++ b/src/main/java/com/cmms11/web/StorageController.java
@@ -8,25 +8,26 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 이름: StorageController
  * 작성자: codex
  * 작성일: 2025-08-20
  * 수정일:
- * 프로그램 개요: 창고(Storage) 기준정보 API 컨트롤러.
+ * 프로그램 개요: 창고(Storage) 기준정보 웹 화면 및 API 엔드포인트를 제공하는 컨트롤러.
  */
-@RestController
-@RequestMapping("/api/domain/storages")
+@Controller
 public class StorageController {
 
     private final StorageService service;
@@ -35,28 +36,75 @@ public class StorageController {
         this.service = service;
     }
 
-    @GetMapping
+    @GetMapping("/domain/storage/list")
+    public String listForm(@RequestParam(name = "q", required = false) String q, Pageable pageable, Model model) {
+        Page<StorageResponse> page = service.list(q, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", q);
+        return "domain/storage/list";
+    }
 
+    @GetMapping("/domain/storage/form")
+    public String newForm(Model model) {
+        model.addAttribute("storage", new StorageResponse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+        model.addAttribute("isNew", true);
+        return "domain/storage/form";
+    }
+
+    @GetMapping("/domain/storage/edit/{storageId}")
+    public String editForm(@PathVariable String storageId, Model model) {
+        StorageResponse storage = service.get(storageId);
+        model.addAttribute("storage", storage);
+        model.addAttribute("isNew", false);
+        return "domain/storage/form";
+    }
+
+    @PostMapping("/domain/storage/save")
+    public String saveForm(@ModelAttribute StorageRequest request, @RequestParam(required = false) String isNew) {
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(request.storageId(), request);
+        }
+        return "redirect:/domain/storage/list";
+    }
+
+    @PostMapping("/domain/storage/delete/{storageId}")
+    public String deleteForm(@PathVariable String storageId) {
+        service.delete(storageId);
+        return "redirect:/domain/storage/list";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/domain/storages")
     public Page<StorageResponse> list(@RequestParam(name = "q", required = false) String q, Pageable pageable) {
-
         return service.list(q, pageable);
     }
 
-    @GetMapping("/{storageId}")
-
+    @ResponseBody
+    @GetMapping("/api/domain/storages/{storageId}")
     public ResponseEntity<StorageResponse> get(@PathVariable String storageId) {
-
         return ResponseEntity.ok(service.get(storageId));
     }
 
-    @PostMapping
-
+    @ResponseBody
+    @PostMapping("/api/domain/storages")
     public ResponseEntity<StorageResponse> create(@Valid @RequestBody StorageRequest request) {
         StorageResponse response = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{storageId}")
+    @ResponseBody
+    @PutMapping("/api/domain/storages/{storageId}")
     public ResponseEntity<StorageResponse> update(
         @PathVariable String storageId,
         @Valid @RequestBody StorageRequest request
@@ -65,10 +113,10 @@ public class StorageController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{storageId}")
+    @ResponseBody
+    @DeleteMapping("/api/domain/storages/{storageId}")
     public ResponseEntity<Void> delete(@PathVariable String storageId) {
         service.delete(storageId);
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/src/main/resources/templates/domain/role/form.html
+++ b/src/main/resources/templates/domain/role/form.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>권한 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>권한 관리</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <a th:href="@{~/domain/role/list}" href="/domain/role/list">권한</a>
+          <span class="sep">/</span>
+          <span>등록/수정</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">권한 등록/수정</div>
+              <div class="toolbar">
+                <a class="btn" th:href="@{~/domain/role/list}" href="/domain/role/list">목록</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="notice">권한 관리 기능은 추후 제공될 예정입니다.</div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 권한 관리</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/domain/role/list.html
+++ b/src/main/resources/templates/domain/role/list.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>권한 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">memberId</span>
+            <span>권한 관리</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>권한</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">권한 목록</div>
+              <div class="toolbar">
+                <a class="btn primary" th:href="@{~/domain/role/form}" href="/domain/role/form">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="notice">권한 관리는 아직 구현되지 않았습니다.</div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 권한 관리</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Thymeleaf-backed list/form handlers to the site, dept, func, and storage controllers while keeping their REST APIs intact
- extend the member controller/service to support web CRUD flows and add richer code management logic for combined type/item maintenance
- introduce placeholder role templates so the new role web routes render without backend support

## Testing
- `./gradlew test` *(fails: Maven Central returned HTTP 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d0799331c48323ada8788500d26903