### PR TITLE
feat: integrate domain and code views into layout

### DIFF
--- a/src/main/java/com/cmms11/domain/member/MemberService.java
+++ b/src/main/java/com/cmms11/domain/member/MemberService.java
@@ -4,6 +4,8 @@ import com.cmms11.common.error.NotFoundException;
 import com.cmms11.security.MemberUserDetailsService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,12 +44,56 @@ public class MemberService {
             throw new IllegalArgumentException("member.id (memberId) is required");
         }
         member.getId().setCompanyId(companyId);
-        if (member.getDeleteMark() == null) member.setDeleteMark("N");
+        if (member.getDeleteMark() == null) {
+            member.setDeleteMark("N");
+        }
         if (rawPassword != null && !rawPassword.isBlank()) {
             member.setPasswordHash(passwordEncoder.encode(rawPassword));
         }
-        member.setCreatedAt(LocalDateTime.now());
-        member.setCreatedBy(actor != null ? actor : "system");
+        LocalDateTime now = LocalDateTime.now();
+        String actorId = actor != null ? actor : currentMemberId();
+        member.setCreatedAt(now);
+        member.setCreatedBy(actorId);
+        member.setUpdatedAt(now);
+        member.setUpdatedBy(actorId);
         return repository.save(member);
+    }
+
+    public Member update(Member member, String rawPassword, String actor) {
+        if (member.getId() == null || member.getId().getMemberId() == null) {
+            throw new IllegalArgumentException("member.id.memberId is required");
+        }
+        Member existing = get(member.getId().getMemberId());
+        existing.setName(member.getName());
+        existing.setDeptId(member.getDeptId());
+        existing.setEmail(member.getEmail());
+        existing.setPhone(member.getPhone());
+        existing.setNote(member.getNote());
+        if (member.getDeleteMark() != null) {
+            existing.setDeleteMark(member.getDeleteMark());
+        }
+        if (rawPassword != null && !rawPassword.isBlank()) {
+            existing.setPasswordHash(passwordEncoder.encode(rawPassword));
+        }
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(actor != null ? actor : currentMemberId());
+        return repository.save(existing);
+    }
+
+    public void delete(String memberId) {
+        Member existing = get(memberId);
+        existing.setDeleteMark("Y");
+        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setUpdatedBy(currentMemberId());
+        repository.save(existing);
+    }
+
+    private String currentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "system";
+        }
+        String name = authentication.getName();
+        return name != null ? name : "system";
     }
 }

--- a/src/main/java/com/cmms11/web/CodeViewController.java
+++ b/src/main/java/com/cmms11/web/CodeViewController.java
@@ -1,0 +1,155 @@
+package com.cmms11.web;
+
+import com.cmms11.code.CodeItemRequest;
+import com.cmms11.code.CodeItemResponse;
+import com.cmms11.code.CodeService;
+import com.cmms11.code.CodeTypeRequest;
+import com.cmms11.code.CodeTypeResponse;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 공통 코드(타입/항목) 화면 컨트롤러.
+ */
+@Controller
+@RequestMapping("/code")
+public class CodeViewController {
+
+    private final CodeService service;
+
+    public CodeViewController(CodeService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/types")
+    public String listTypes(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<CodeTypeResponse> page = service.listTypes(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "code/list";
+    }
+
+    @GetMapping({"/types/new", "/types/form"})
+    public String newTypeForm(Model model) {
+        model.addAttribute("type", emptyType());
+        model.addAttribute("isNew", true);
+        return "code/form";
+    }
+
+    @GetMapping("/types/{codeType}")
+    public String editTypeForm(@PathVariable String codeType, Model model) {
+        model.addAttribute("type", service.getType(codeType));
+        model.addAttribute("isNew", false);
+        return "code/form";
+    }
+
+    @PostMapping("/types/save")
+    public String saveType(
+        @RequestParam String codeType,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        CodeTypeRequest request = new CodeTypeRequest(codeType, name, note);
+        if ("true".equals(isNew)) {
+            service.createType(request);
+        } else {
+            service.updateType(codeType, request);
+        }
+        return "redirect:/code/types";
+    }
+
+    @PostMapping("/types/delete/{codeType}")
+    public String deleteType(@PathVariable String codeType) {
+        service.deleteType(codeType);
+        return "redirect:/code/types";
+    }
+
+    @GetMapping("/items")
+    public String listItems(
+        @RequestParam(name = "codeType", required = false) String codeType,
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        List<CodeTypeResponse> types = service.listTypes(null, PageRequest.of(0, 100)).getContent();
+        model.addAttribute("codeTypes", types);
+        model.addAttribute("selectedType", codeType);
+        model.addAttribute("keyword", keyword);
+
+        Page<CodeItemResponse> page = Page.empty(pageable);
+        if (codeType != null && !codeType.isBlank()) {
+            page = service.listItems(codeType, keyword, pageable);
+        }
+        model.addAttribute("page", page);
+        return "code/item-list";
+    }
+
+    @GetMapping("/items/new")
+    public String newItemForm(
+        @RequestParam String codeType,
+        Model model
+    ) {
+        model.addAttribute("type", service.getType(codeType));
+        model.addAttribute("item", emptyItem(codeType));
+        model.addAttribute("isNew", true);
+        return "code/item-form";
+    }
+
+    @GetMapping("/items/{codeType}/{code}")
+    public String editItemForm(
+        @PathVariable String codeType,
+        @PathVariable String code,
+        Model model
+    ) {
+        model.addAttribute("type", service.getType(codeType));
+        model.addAttribute("item", service.getItem(codeType, code));
+        model.addAttribute("isNew", false);
+        return "code/item-form";
+    }
+
+    @PostMapping("/items/save")
+    public String saveItem(
+        @RequestParam String codeType,
+        @RequestParam String code,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        CodeItemRequest request = new CodeItemRequest(codeType, code, name, note);
+        if ("true".equals(isNew)) {
+            service.createItem(request);
+        } else {
+            service.updateItem(codeType, code, request);
+        }
+        return "redirect:/code/items?codeType=" + codeType;
+    }
+
+    @PostMapping("/items/delete/{codeType}/{code}")
+    public String deleteItem(@PathVariable String codeType, @PathVariable String code) {
+        service.deleteItem(codeType, code);
+        return "redirect:/code/items?codeType=" + codeType;
+    }
+
+    private CodeTypeResponse emptyType() {
+        return new CodeTypeResponse(null, null, null, "N", null, null, null, null);
+    }
+
+    private CodeItemResponse emptyItem(String codeType) {
+        return new CodeItemResponse(codeType, null, null, null);
+    }
+}
+

--- a/src/main/java/com/cmms11/web/DeptViewController.java
+++ b/src/main/java/com/cmms11/web/DeptViewController.java
@@ -1,0 +1,90 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.dept.DeptRequest;
+import com.cmms11.domain.dept.DeptResponse;
+import com.cmms11.domain.dept.DeptService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 부서 기준정보 웹 화면 컨트롤러.
+ */
+@Controller
+@RequestMapping("/domain/dept")
+public class DeptViewController {
+
+    private final DeptService service;
+
+    public DeptViewController(DeptService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    public String list(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<DeptResponse> page = service.list(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "domain/dept/list";
+    }
+
+    @GetMapping("/form")
+    public String newForm(Model model) {
+        model.addAttribute("dept", emptyDept());
+        model.addAttribute("isNew", true);
+        return "domain/dept/form";
+    }
+
+    @GetMapping("/edit/{deptId}")
+    public String editForm(@PathVariable String deptId, Model model) {
+        model.addAttribute("dept", service.get(deptId));
+        model.addAttribute("isNew", false);
+        return "domain/dept/form";
+    }
+
+    @PostMapping("/save")
+    public String save(
+        @RequestParam String deptId,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        DeptRequest request = new DeptRequest(deptId, name, note);
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(deptId, request);
+        }
+        return "redirect:/domain/dept/list";
+    }
+
+    @PostMapping("/delete/{deptId}")
+    public String delete(@PathVariable String deptId) {
+        service.delete(deptId);
+        return "redirect:/domain/dept/list";
+    }
+
+    private DeptResponse emptyDept() {
+        return new DeptResponse(
+            null,
+            null,
+            null,
+            "N",
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/web/FuncViewController.java
+++ b/src/main/java/com/cmms11/web/FuncViewController.java
@@ -1,0 +1,90 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.func.FuncRequest;
+import com.cmms11.domain.func.FuncResponse;
+import com.cmms11.domain.func.FuncService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 기능위치(view) 컨트롤러.
+ */
+@Controller
+@RequestMapping("/domain/func")
+public class FuncViewController {
+
+    private final FuncService service;
+
+    public FuncViewController(FuncService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    public String list(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<FuncResponse> page = service.list(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "domain/func/list";
+    }
+
+    @GetMapping("/form")
+    public String newForm(Model model) {
+        model.addAttribute("func", emptyFunc());
+        model.addAttribute("isNew", true);
+        return "domain/func/form";
+    }
+
+    @GetMapping("/edit/{funcId}")
+    public String editForm(@PathVariable String funcId, Model model) {
+        model.addAttribute("func", service.get(funcId));
+        model.addAttribute("isNew", false);
+        return "domain/func/form";
+    }
+
+    @PostMapping("/save")
+    public String save(
+        @RequestParam String funcId,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        FuncRequest request = new FuncRequest(funcId, name, note);
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(funcId, request);
+        }
+        return "redirect:/domain/func/list";
+    }
+
+    @PostMapping("/delete/{funcId}")
+    public String delete(@PathVariable String funcId) {
+        service.delete(funcId);
+        return "redirect:/domain/func/list";
+    }
+
+    private FuncResponse emptyFunc() {
+        return new FuncResponse(
+            null,
+            null,
+            null,
+            "N",
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/web/MemberViewController.java
+++ b/src/main/java/com/cmms11/web/MemberViewController.java
@@ -1,0 +1,204 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.member.Member;
+import com.cmms11.domain.member.MemberId;
+import com.cmms11.domain.member.MemberService;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 사용자(회원) 기준정보 화면 컨트롤러.
+ */
+@Controller
+@RequestMapping("/domain/member")
+@Validated
+public class MemberViewController {
+
+    private final MemberService service;
+
+    public MemberViewController(MemberService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    public String list(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<Member> page = service.list(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "domain/member/list";
+    }
+
+    @GetMapping("/form")
+    public String newForm(Model model) {
+        model.addAttribute("member", MemberForm.empty());
+        model.addAttribute("isNew", true);
+        return "domain/member/form";
+    }
+
+    @GetMapping("/edit/{memberId}")
+    public String editForm(@PathVariable String memberId, Model model) {
+        Member member = service.get(memberId);
+        model.addAttribute("member", MemberForm.from(member));
+        model.addAttribute("isNew", false);
+        return "domain/member/form";
+    }
+
+    @PostMapping("/save")
+    public String save(
+        @ModelAttribute @Validated MemberForm form,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        if ("true".equals(isNew)) {
+            service.create(form.toEntity(), form.getPassword(), null);
+        } else {
+            service.update(form.toEntity(), form.getPassword(), null);
+        }
+        return "redirect:/domain/member/list";
+    }
+
+    @PostMapping("/delete/{memberId}")
+    public String delete(@PathVariable String memberId) {
+        service.delete(memberId);
+        return "redirect:/domain/member/list";
+    }
+
+    /**
+     * 화면과 서비스 계층 사이의 폼 데이터 매핑용 클래스.
+     */
+    public static class MemberForm {
+
+        @NotBlank
+        @Size(max = 5)
+        private String memberId;
+
+        @NotBlank
+        @Size(max = 100)
+        private String name;
+
+        @Size(max = 5)
+        private String deptId;
+
+        @Size(max = 100)
+        private String email;
+
+        @Size(max = 100)
+        private String phone;
+
+        @Size(max = 500)
+        private String note;
+
+        @Size(max = 1)
+        private String deleteMark = "N";
+
+        @Size(max = 100)
+        private String password;
+
+        public static MemberForm empty() {
+            return new MemberForm();
+        }
+
+        public static MemberForm from(Member member) {
+            MemberForm form = new MemberForm();
+            form.setMemberId(member.getId().getMemberId());
+            form.setName(member.getName());
+            form.setDeptId(member.getDeptId());
+            form.setEmail(member.getEmail());
+            form.setPhone(member.getPhone());
+            form.setNote(member.getNote());
+            form.setDeleteMark(member.getDeleteMark());
+            return form;
+        }
+
+        public Member toEntity() {
+            Member member = new Member();
+            member.setId(new MemberId(null, memberId));
+            member.setName(name);
+            member.setDeptId(deptId);
+            member.setEmail(email);
+            member.setPhone(phone);
+            member.setNote(note);
+            member.setDeleteMark(deleteMark != null ? deleteMark : "N");
+            return member;
+        }
+
+        public String getMemberId() {
+            return memberId;
+        }
+
+        public void setMemberId(String memberId) {
+            this.memberId = memberId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDeptId() {
+            return deptId;
+        }
+
+        public void setDeptId(String deptId) {
+            this.deptId = deptId;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public void setPhone(String phone) {
+            this.phone = phone;
+        }
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+
+        public String getDeleteMark() {
+            return deleteMark;
+        }
+
+        public void setDeleteMark(String deleteMark) {
+            this.deleteMark = deleteMark;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}
+

--- a/src/main/java/com/cmms11/web/RoleViewController.java
+++ b/src/main/java/com/cmms11/web/RoleViewController.java
@@ -1,0 +1,22 @@
+package com.cmms11.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 권한 관리 화면용 뷰 컨트롤러.
+ * 현재는 기능 준비중 메시지만 노출한다.
+ */
+@Controller
+@RequestMapping("/domain/role")
+public class RoleViewController {
+
+    @GetMapping("/list")
+    public String list(Model model) {
+        model.addAttribute("ready", Boolean.TRUE);
+        return "domain/role/list";
+    }
+}
+

--- a/src/main/java/com/cmms11/web/SiteViewController.java
+++ b/src/main/java/com/cmms11/web/SiteViewController.java
@@ -1,0 +1,90 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.site.SiteRequest;
+import com.cmms11.domain.site.SiteResponse;
+import com.cmms11.domain.site.SiteService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 화면과 Service 계층을 연결하는 사업장(view) 컨트롤러.
+ */
+@Controller
+@RequestMapping("/domain/site")
+public class SiteViewController {
+
+    private final SiteService service;
+
+    public SiteViewController(SiteService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    public String list(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<SiteResponse> page = service.list(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "domain/site/list";
+    }
+
+    @GetMapping("/form")
+    public String newForm(Model model) {
+        model.addAttribute("site", emptySite());
+        model.addAttribute("isNew", true);
+        return "domain/site/form";
+    }
+
+    @GetMapping("/edit/{siteId}")
+    public String editForm(@PathVariable String siteId, Model model) {
+        model.addAttribute("site", service.get(siteId));
+        model.addAttribute("isNew", false);
+        return "domain/site/form";
+    }
+
+    @PostMapping("/save")
+    public String save(
+        @RequestParam String siteId,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        SiteRequest request = new SiteRequest(siteId, name, note);
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(siteId, request);
+        }
+        return "redirect:/domain/site/list";
+    }
+
+    @PostMapping("/delete/{siteId}")
+    public String delete(@PathVariable String siteId) {
+        service.delete(siteId);
+        return "redirect:/domain/site/list";
+    }
+
+    private SiteResponse emptySite() {
+        return new SiteResponse(
+            null,
+            null,
+            null,
+            "N",
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}
+

--- a/src/main/java/com/cmms11/web/StorageViewController.java
+++ b/src/main/java/com/cmms11/web/StorageViewController.java
@@ -1,0 +1,90 @@
+package com.cmms11.web;
+
+import com.cmms11.domain.storage.StorageRequest;
+import com.cmms11.domain.storage.StorageResponse;
+import com.cmms11.domain.storage.StorageService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 창고 기준정보 화면 컨트롤러.
+ */
+@Controller
+@RequestMapping("/domain/storage")
+public class StorageViewController {
+
+    private final StorageService service;
+
+    public StorageViewController(StorageService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    public String list(
+        @RequestParam(name = "q", required = false) String keyword,
+        Pageable pageable,
+        Model model
+    ) {
+        Page<StorageResponse> page = service.list(keyword, pageable);
+        model.addAttribute("page", page);
+        model.addAttribute("keyword", keyword);
+        return "domain/storage/list";
+    }
+
+    @GetMapping("/form")
+    public String newForm(Model model) {
+        model.addAttribute("storage", emptyStorage());
+        model.addAttribute("isNew", true);
+        return "domain/storage/form";
+    }
+
+    @GetMapping("/edit/{storageId}")
+    public String editForm(@PathVariable String storageId, Model model) {
+        model.addAttribute("storage", service.get(storageId));
+        model.addAttribute("isNew", false);
+        return "domain/storage/form";
+    }
+
+    @PostMapping("/save")
+    public String save(
+        @RequestParam String storageId,
+        @RequestParam String name,
+        @RequestParam(name = "note", required = false) String note,
+        @RequestParam(name = "isNew", required = false) String isNew
+    ) {
+        StorageRequest request = new StorageRequest(storageId, name, note);
+        if ("true".equals(isNew)) {
+            service.create(request);
+        } else {
+            service.update(storageId, request);
+        }
+        return "redirect:/domain/storage/list";
+    }
+
+    @PostMapping("/delete/{storageId}")
+    public String delete(@PathVariable String storageId) {
+        service.delete(storageId);
+        return "redirect:/domain/storage/list";
+    }
+
+    private StorageResponse emptyStorage() {
+        return new StorageResponse(
+            null,
+            null,
+            null,
+            "N",
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}
+

--- a/src/main/resources/templates/code/form.html
+++ b/src/main/resources/templates/code/form.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>공통코드 등록/수정 · CMMS</title>
+    <title>코드 타입 등록/수정 · CMMS</title>
     <link rel="stylesheet" href="../../static/assets/css/base.css" />
   </head>
   <body>
@@ -13,8 +13,8 @@
           <div class="brand">공통코드</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영자</span>
+            <span class="badge">codetype</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,7 +22,7 @@
         <div class="container">
           <a href="#">공통코드</a>
           <span class="sep">/</span>
-          <a href="list.html">목록</a>
+          <a th:href="@{/code/types}" href="/code/types">코드 타입</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -31,67 +31,52 @@
         <div class="container">
           <section class="card">
             <div class="card-header">
-              <div class="card-title">공통코드 등록/수정</div>
+              <div class="card-title">코드 타입 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" href="list.html">목록</a>
+                <a class="btn" th:href="@{/code/types}" href="/code/types">목록</a>
+                <a class="btn" th:if="${!isNew}" th:href="@{|/code/items?codeType=${type.codeType}|}">항목 관리</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate>
-
+              <form data-validate method="post" action="/code/types/save" data-redirect="/code/types">
                 <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-                <!-- 코드 타입 헤더 -->
+                <input type="hidden" name="isNew" th:value="${isNew}" />
+
                 <div class="section">
-                  <div class="section-title">코드 타입</div>
+                  <div class="section-title">기본정보</div>
                   <div class="grid cols-12">
-                    <div class="form-row col-span-3">
+                    <div class="form-row col-span-4">
                       <label class="label required" for="code_type">코드타입</label>
-                      <input id="code_type" name="code_type" class="input" required maxlength="5" placeholder="예: JOBTP" />
+                      <input id="code_type"
+                             name="codeType"
+                             class="input"
+                             required
+                             maxlength="5"
+                             placeholder="예: JOBTP"
+                             th:value="${type.codeType}"
+                             th:readonly="${!isNew}" />
                     </div>
-                    <div class="form-row col-span-9">
+                    <div class="form-row col-span-8">
                       <label class="label required" for="name">명칭</label>
-                      <input id="name" name="name" class="input" required maxlength="100" placeholder="예: 작업유형" />
+                      <input id="name" name="name" class="input" required maxlength="100" th:value="${type.name}" />
                     </div>
-                    <div class="form-row col-span-12">
-                      <label class="label" for="note">비고</label>
-                      <input id="note" name="note" class="input" maxlength="500" placeholder="예: REPR/PM/IMPR 등" />
-                    </div>
+                  </div>
+                  <div class="form-row col-span-12">
+                    <label class="label" for="note">비고</label>
+                    <textarea id="note"
+                              name="note"
+                              rows="4"
+                              maxlength="500"
+                              placeholder="코드 타입 설명"
+                              th:text="${type.note}"></textarea>
                   </div>
                 </div>
 
-                <!-- 코드 항목 (code_item) -->
-                <div class="section" data-code-items>
-                  <div class="section-title">코드 항목</div>
-                  <div class="section-desc">code_item 기준: 코드, 명칭, 비고</div>
-                  <table class="table">
-                    <thead>
-                      <tr>
-                        <th style="width:44px">#</th>
-                        <th style="width:140px">코드</th>
-                        <th>명칭</th>
-                        <th>비고</th>
-                        <th style="width:80px"></th>
-                      </tr>
-                    </thead>
-                    <tbody id="code-items-body">
-                      <tr class="code-item-row">
-                        <td class="cell-center line-no">1</td>
-                        <td><input class="input" name="items[0].code" required maxlength="5" placeholder="예: REPR" /></td>
-                        <td><input class="input" name="items[0].name" required maxlength="100" placeholder="예: 수리" /></td>
-                        <td><input class="input" name="items[0].note" maxlength="500" placeholder="" /></td>
-                        <td class="cell-center"><button type="button" class="btn sm danger" data-remove-item style="display:none">삭제</button></td>
-                      </tr>
-                    </tbody>
-                  </table>
-                  <div class="actions" style="justify-content:flex-start;margin-top:8px">
-                    <button type="button" class="btn sm" data-add-item>항목 추가</button>
-                  </div>
-                </div>
-
-                <div class="actions" style="margin-top:16px">
-                  <button class="btn" type="button" onclick="history.back()">취소</button>
+                <div class="row" style="margin-top:16px; gap:8px; justify-content:flex-end">
                   <button class="btn" type="reset">초기화</button>
-                  <button class="btn primary" type="submit">저장</button>
+                  <button class="btn primary" type="submit">
+                    <span th:text="${isNew ? '등록' : '수정'}">등록</span>
+                  </button>
                 </div>
               </form>
             </div>
@@ -103,54 +88,5 @@
       </footer>
     </div>
     <script src="../../static/assets/js/app.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const section = document.querySelector('[data-code-items]');
-        if (!section) return;
-        const tbody = section.querySelector('#code-items-body');
-        const addBtn = section.querySelector('[data-add-item]');
-
-        function renumber() {
-          tbody.querySelectorAll('.code-item-row').forEach((tr, i) => {
-            tr.querySelector('.line-no').textContent = i + 1;
-            tr.querySelectorAll('input').forEach((inp) => {
-              const field = inp.name.split('.').pop();
-              inp.name = `items[${i}].${field}`;
-            });
-            const delBtn = tr.querySelector('[data-remove-item]');
-            if (delBtn) delBtn.style.display = i === 0 ? 'none' : 'inline-flex';
-          });
-        }
-
-        function addRow() {
-          const i = tbody.querySelectorAll('.code-item-row').length;
-          const tr = document.createElement('tr');
-          tr.className = 'code-item-row';
-          tr.innerHTML = `
-            <td class="cell-center line-no">${i + 1}</td>
-            <td><input class="input" name="items[${i}].code" required maxlength="5" placeholder="예: REPR" /></td>
-            <td><input class="input" name="items[${i}].name" required maxlength="100" placeholder="예: 수리" /></td>
-            <td><input class="input" name="items[${i}].note" maxlength="500" placeholder="" /></td>
-            <td class="cell-center"><button type="button" class="btn sm danger" data-remove-item>삭제</button></td>`;
-          tbody.appendChild(tr);
-          attachRowHandlers(tr);
-          renumber();
-        }
-
-        function attachRowHandlers(tr) {
-          const delBtn = tr.querySelector('[data-remove-item]');
-          delBtn?.addEventListener('click', () => {
-            tr.remove();
-            renumber();
-          });
-        }
-
-        // init
-        tbody.querySelectorAll('.code-item-row').forEach(attachRowHandlers);
-        renumber();
-        addBtn?.addEventListener('click', addRow);
-      });
-    </script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/code/item-form.html
+++ b/src/main/resources/templates/code/item-form.html
@@ -3,26 +3,26 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>기능위치 등록/수정 · CMMS</title>
-    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+    <title>코드 항목 등록/수정 · CMMS</title>
+    <link rel="stylesheet" href="../../static/assets/css/base.css" />
   </head>
   <body>
     <div class="page">
       <header class="appbar">
         <div class="appbar-inner">
-          <div class="brand">기본정보</div>
+          <div class="brand">공통코드</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">func</span>
-            <span>관리</span>
+            <span class="badge">codeitem</span>
+            <span th:text="${type.codeType}">TYPE</span>
           </div>
         </div>
       </header>
       <nav class="breadcrumbs">
         <div class="container">
-          <a href="#">기본정보</a>
+          <a href="#">공통코드</a>
           <span class="sep">/</span>
-          <a th:href="@{/domain/func/list}" href="/domain/func/list">기능위치</a>
+          <a th:href="@{/code/items(codeType=${type.codeType})}" th:text="${type.codeType + ' 항목'}">코드 항목</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -31,38 +31,41 @@
         <div class="container">
           <section class="card">
             <div class="card-header">
-              <div class="card-title">기능위치 등록/수정</div>
+              <div class="card-title">코드 항목 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" th:href="@{/domain/func/list}" href="/domain/func/list">목록</a>
+                <a class="btn" th:href="@{/code/items(codeType=${type.codeType})}">목록</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate method="post" action="/domain/func/save" data-redirect="/domain/func/list">
+              <form data-validate method="post" action="/code/items/save" th:attr="data-redirect=@{|/code/items?codeType=${type.codeType}|}">
                 <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <input type="hidden" name="isNew" th:value="${isNew}" />
+                <input type="hidden" name="codeType" th:value="${type.codeType}" />
 
                 <div class="section">
-                  <div class="section-title">기본정보</div>
+                  <div class="section-title">코드 타입</div>
+                  <div class="form-row">
+                    <input class="input" readonly th:value="${type.codeType + ' - ' + (type.name != null ? type.name : '')}" />
+                  </div>
+                </div>
+
+                <div class="section">
+                  <div class="section-title">항목 정보</div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
-                      <label class="label required" for="func_id">기능위치코드</label>
-                      <input id="func_id"
-                             name="funcId"
+                      <label class="label required" for="code">코드</label>
+                      <input id="code"
+                             name="code"
                              class="input"
                              required
                              maxlength="5"
-                             placeholder="예: F0001"
-                             th:value="${func.funcId}"
+                             placeholder="예: REPR"
+                             th:value="${item.code}"
                              th:readonly="${!isNew}" />
                     </div>
                     <div class="form-row col-span-8">
-                      <label class="label required" for="func_name">기능위치명</label>
-                      <input id="func_name"
-                             name="name"
-                             class="input"
-                             required
-                             maxlength="100"
-                             th:value="${func.name}" />
+                      <label class="label required" for="name">명칭</label>
+                      <input id="name" name="name" class="input" required maxlength="100" th:value="${item.name}" />
                     </div>
                   </div>
                   <div class="form-row col-span-12">
@@ -71,12 +74,12 @@
                               name="note"
                               rows="4"
                               maxlength="500"
-                              placeholder="기타 메모(최대 500자)"
-                              th:text="${func.note}"></textarea>
+                              placeholder="항목 설명"
+                              th:text="${item.note}"></textarea>
                   </div>
                 </div>
 
-                <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
+                <div class="row" style="margin-top:16px; gap:8px; justify-content:flex-end">
                   <button class="btn" type="reset">초기화</button>
                   <button class="btn primary" type="submit">
                     <span th:text="${isNew ? '등록' : '수정'}">등록</span>
@@ -88,9 +91,9 @@
         </div>
       </main>
       <footer>
-        <div class="container">© 기본정보</div>
+        <div class="container">© 공통코드</div>
       </footer>
     </div>
-    <script src="../../../static/assets/js/app.js"></script>
+    <script src="../../static/assets/js/app.js"></script>
   </body>
 </html>

--- a/src/main/resources/templates/code/item-list.html
+++ b/src/main/resources/templates/code/item-list.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>코드 항목 목록 · CMMS</title>
+    <link rel="stylesheet" href="../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">공통코드</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">codeitem</span>
+            <span>관리</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">공통코드</a>
+          <span class="sep">/</span>
+          <span>코드 항목</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">코드 항목 목록</div>
+              <div class="toolbar">
+                <a class="btn primary" th:if="${selectedType != null}" th:href="@{|/code/items/new?codeType=${selectedType}|}">새로 만들기</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <form class="section" method="get" th:action="@{/code/items}">
+                <div class="section-title">필터</div>
+                <div class="grid cols-12" style="row-gap:12px">
+                  <div class="col-span-4">
+                    <label class="label" for="code_type">코드타입</label>
+                    <select id="code_type" name="codeType">
+                      <option value="">(선택)</option>
+                      <option th:each="type : ${codeTypes}"
+                              th:value="${type.codeType}"
+                              th:selected="${type.codeType == selectedType}"
+                              th:text="${type.codeType + ' - ' + (type.name != null ? type.name : '')}">
+                        TYPE
+                      </option>
+                    </select>
+                  </div>
+                  <div class="col-span-4">
+                    <label class="label" for="q">명칭</label>
+                    <input id="q" class="input" name="q" placeholder="코드 또는 명칭" th:value="${keyword}" />
+                  </div>
+                  <div class="col-span-4" style="display:flex;align-items:flex-end;gap:8px;justify-content:flex-end">
+                    <a class="btn" th:href="@{/code/items}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
+                  </div>
+                </div>
+              </form>
+
+              <div th:if="${selectedType == null}">
+                <div class="notice info" style="margin-top:12px">코드타입을 선택하면 항목 목록이 표시됩니다.</div>
+              </div>
+
+              <table class="table" th:if="${selectedType != null}">
+                <thead>
+                  <tr>
+                    <th style="width:120px">코드</th>
+                    <th>명칭</th>
+                    <th>비고</th>
+                    <th style="width:140px">액션</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr th:if="${page.empty}">
+                    <td colspan="4" class="cell-center muted">선택한 코드타입에 대한 항목이 없습니다.</td>
+                  </tr>
+                  <tr th:each="item : ${page.content}" th:data-row-link="@{|/code/items/${item.codeType}/${item.code}|}">
+                    <td><a th:href="@{|/code/items/${item.codeType}/${item.code}|}" th:text="${item.code}">CODE</a></td>
+                    <td th:text="${item.name}">-</td>
+                    <td th:text="${item.note}">-</td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/code/items/${item.codeType}/${item.code}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/code/items/delete/${item.codeType}/${item.code}|},data-redirect=@{|/code/items?codeType=${item.codeType}|},data-confirm=${'코드 ' + item.code + '을 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="row" style="margin-top:12px" th:if="${selectedType != null}">
+                <div class="spacer"></div>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{|/code/items?codeType=${selectedType}&q=${keyword}&page=${page.number > 0 ? page.number - 1 : 0}&size=${page.size}|}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{|/code/items?codeType=${selectedType}&q=${keyword}&page=${page.last ? page.number : page.number + 1}&size=${page.size}|}">다음</a>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 공통코드</div>
+      </footer>
+    </div>
+    <script src="../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/code/list.html
+++ b/src/main/resources/templates/code/list.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>공통코드 목록 · CMMS</title>
+    <title>코드 타입 목록 · CMMS</title>
     <link rel="stylesheet" href="../../static/assets/css/base.css" />
   </head>
   <body>
@@ -13,8 +13,8 @@
           <div class="brand">공통코드</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영자</span>
+            <span class="badge">codetype</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,31 +22,29 @@
         <div class="container">
           <a href="#">공통코드</a>
           <span class="sep">/</span>
-          <span>목록</span>
+          <span>코드 타입</span>
         </div>
       </nav>
       <main>
         <div class="container">
           <section class="card">
             <div class="card-header">
-              <div class="card-title">공통코드 목록</div>
+              <div class="card-title">코드 타입 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">내보내기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/code/types/new}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/code/types}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3"><input class="input" placeholder="코드타입" /></div>
-                  <div class="col-span-5"><input class="input" placeholder="명칭" /></div>
+                  <div class="col-span-4"><input class="input" name="q" placeholder="코드타입 또는 명" th:value="${keyword}" /></div>
+                  <div class="col-span-8" style="display:flex;gap:8px;justify-content:flex-end">
+                    <a class="btn" th:href="@{/code/types}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
+                  </div>
                 </div>
-                <div class="row" style="margin-top:8px;justify-content:flex-end;gap:8px">
-                  <button class="btn">초기화</button>
-                  <button class="btn">검색</button>
-                </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
@@ -54,27 +52,40 @@
                     <th style="width:120px">코드타입</th>
                     <th>명칭</th>
                     <th>비고</th>
+                    <th style="width:140px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">JOBTP</a></td>
-                    <td>작업유형</td>
-                    <td class="muted">REPR, PM 등</td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="4" class="cell-center muted">등록된 코드 타입이 없습니다.</td>
                   </tr>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">PERMT</a></td>
-                    <td>작업허가유형</td>
-                    <td class="muted">HOT, CONF 등</td>
+                  <tr th:each="type : ${page.content}" th:data-row-link="@{|/code/types/${type.codeType}|}">
+                    <td><a th:href="@{|/code/types/${type.codeType}|}" th:text="${type.codeType}">TYPE</a></td>
+                    <td th:text="${type.name}">-</td>
+                    <td th:text="${type.note}">-</td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/code/types/${type.codeType}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/code/items?codeType=${type.codeType}|}">항목</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/code/types/delete/${type.codeType}|},data-redirect=@{/code/types},data-confirm=${'코드타입 ' + type.codeType + '을 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/code/types(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/code/types(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>
@@ -87,5 +98,4 @@
     </div>
     <script src="../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/dept/form.html
+++ b/src/main/resources/templates/domain/dept/form.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">dept</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,7 +22,7 @@
         <div class="container">
           <a href="#">기본정보</a>
           <span class="sep">/</span>
-          <a href="list.html">부서</a>
+          <a th:href="@{/domain/dept/list}" href="/domain/dept/list">부서</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -33,56 +33,54 @@
             <div class="card-header">
               <div class="card-title">부서 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" href="list.html">목록</a>
+                <a class="btn" th:href="@{/domain/dept/list}" href="/domain/dept/list">목록</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate>
-
+              <form data-validate method="post" action="/domain/dept/save" data-redirect="/domain/dept/list">
                 <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" name="isNew" th:value="${isNew}" />
+
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
                       <label class="label required" for="dept_id">부서코드</label>
-                      <input id="dept_id" name="dept_id" class="input" required maxlength="10" placeholder="예: D0001" />
+                      <input id="dept_id"
+                             name="deptId"
+                             class="input"
+                             required
+                             maxlength="5"
+                             placeholder="예: D0001"
+                             th:value="${dept.deptId}"
+                             th:readonly="${!isNew}" />
                     </div>
-                    <div class="form-row col-span-4">
+                    <div class="form-row col-span-8">
                       <label class="label required" for="dept_name">부서명</label>
-                      <input id="dept_name" name="dept_name" class="input" required maxlength="100" />
-                    </div>
-                    <div class="form-row col-span-4">
-                      <label class="label required" for="site_id">사업장코드</label>
-                      <select id="site_id" name="site_id" required>
-                        <option value="">(선택)</option>
-                        <option value="S0001">S0001</option>
-                      </select>
-                    </div>
-                  </div>
-                  <div class="grid cols-12">
-                    <div class="form-row col-span-4">
-                      <label class="label" for="parent_dept_id">상위부서</label>
-                      <select id="parent_dept_id" name="parent_dept_id">
-                        <option value="">(없음)</option>
-                      </select>
-                    </div>
-                    <div class="form-row col-span-4">
-                      <label class="label" for="status">상태</label>
-                      <select id="status" name="status">
-                        <option value="ACTIVE">정상</option>
-                        <option value="INACTIVE">중지</option>
-                      </select>
+                      <input id="dept_name"
+                             name="name"
+                             class="input"
+                             required
+                             maxlength="100"
+                             th:value="${dept.name}" />
                     </div>
                   </div>
                   <div class="form-row col-span-12">
                     <label class="label" for="note">비고</label>
-                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                    <textarea id="note"
+                              name="note"
+                              rows="4"
+                              maxlength="500"
+                              placeholder="기타 메모(최대 500자)"
+                              th:text="${dept.note}"></textarea>
                   </div>
                 </div>
 
                 <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
                   <button class="btn" type="reset">초기화</button>
-                  <button class="btn primary" type="submit">저장</button>
+                  <button class="btn primary" type="submit">
+                    <span th:text="${isNew ? '등록' : '수정'}">등록</span>
+                  </button>
                 </div>
               </form>
             </div>
@@ -95,5 +93,4 @@
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/dept/list.html
+++ b/src/main/resources/templates/domain/dept/list.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">dept</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -31,56 +31,67 @@
             <div class="card-header">
               <div class="card-title">부서 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">정보보기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/domain/dept/form}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/domain/dept/list}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3">
-                    <input class="input" placeholder="부서코드" />
+                  <div class="col-span-6">
+                    <input class="input" name="q" placeholder="부서 코드 또는 명" th:value="${keyword}" />
                   </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="부서명" />
-                  </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="사업장코드" />
-                  </div>
-                  <div class="col-span-3" style="display:flex;gap:8px;justify-content:flex-end">
-                    <button class="btn">초기화</button>
-                    <button class="btn">검색</button>
+                  <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
+                    <a class="btn" th:href="@{/domain/dept/list}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
                   </div>
                 </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
                   <tr>
                     <th style="width:140px">부서코드</th>
                     <th>부서명</th>
-                    <th style="width:140px">사업장코드</th>
-                    <th style="width:160px">상위부서</th>
+                    <th>비고</th>
                     <th style="width:120px">상태</th>
+                    <th style="width:160px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">D0001</a></td>
-                    <td>설비팀</td>
-                    <td>S0001</td>
-                    <td>(없음)</td>
-                    <td><span class="badge">정상</span></td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="5" class="cell-center muted">등록된 부서가 없습니다.</td>
+                  </tr>
+                  <tr th:each="dept : ${page.content}" th:data-row-link="@{|/domain/dept/edit/${dept.deptId}|}">
+                    <td><a th:href="@{|/domain/dept/edit/${dept.deptId}|}" th:text="${dept.deptId}">DEPT</a></td>
+                    <td th:text="${dept.name}">-</td>
+                    <td th:text="${dept.note}">-</td>
+                    <td>
+                      <span class="badge" th:text="${dept.deleteMark == 'Y' ? '중지' : '정상'}"
+                            th:classappend="${dept.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
+                    </td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/domain/dept/edit/${dept.deptId}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/domain/dept/delete/${dept.deptId}|},data-redirect=@{/domain/dept/list},data-confirm=${'부서 ' + dept.deptId + '을 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/domain/dept/list(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/domain/dept/list(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>
@@ -93,5 +104,4 @@
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/func/list.html
+++ b/src/main/resources/templates/domain/func/list.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-
     <title>기능위치 목록 · CMMS</title>
     <link rel="stylesheet" href="../../../static/assets/css/base.css" />
   </head>
@@ -14,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">func</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -32,49 +31,67 @@
             <div class="card-header">
               <div class="card-title">기능위치 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">정보보기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/domain/func/form}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/domain/func/list}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3">
-                    <input class="input" placeholder="기능위치 코드" />
-                  </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="기능위치 명" />
+                  <div class="col-span-6">
+                    <input class="input" name="q" placeholder="기능위치 코드 또는 명" th:value="${keyword}" />
                   </div>
                   <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
-                    <button class="btn">초기화</button>
-                    <button class="btn">검색</button>
+                    <a class="btn" th:href="@{/domain/func/list}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
                   </div>
                 </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
                   <tr>
-                    <th style="width:140px">기능위치 코드</th>
-                    <th>기능위치 명</th>
-                    <th style="width:200px">비고</th>
+                    <th style="width:140px">기능위치코드</th>
+                    <th>기능위치명</th>
+                    <th>비고</th>
+                    <th style="width:120px">상태</th>
+                    <th style="width:160px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">F001</a></td>
-                    <td>펌프 라인</td>
-                    <td>예시 데이터</td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="5" class="cell-center muted">등록된 기능위치가 없습니다.</td>
+                  </tr>
+                  <tr th:each="func : ${page.content}" th:data-row-link="@{|/domain/func/edit/${func.funcId}|}">
+                    <td><a th:href="@{|/domain/func/edit/${func.funcId}|}" th:text="${func.funcId}">FUNC</a></td>
+                    <td th:text="${func.name}">-</td>
+                    <td th:text="${func.note}">-</td>
+                    <td>
+                      <span class="badge" th:text="${func.deleteMark == 'Y' ? '중지' : '정상'}"
+                            th:classappend="${func.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
+                    </td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/domain/func/edit/${func.funcId}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/domain/func/delete/${func.funcId}|},data-redirect=@{/domain/func/list},data-confirm=${'기능위치 ' + func.funcId + '를 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/domain/func/list(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/domain/func/list(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>

--- a/src/main/resources/templates/domain/member/form.html
+++ b/src/main/resources/templates/domain/member/form.html
@@ -10,11 +10,11 @@
     <div class="page">
       <header class="appbar">
         <div class="appbar-inner">
-          <div class="brand">사용자 관리</div>
+          <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>님 환영합니다</span>
+            <span class="badge">member</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,7 +22,7 @@
         <div class="container">
           <a href="#">기본정보</a>
           <span class="sep">/</span>
-          <a href="list.html">사용자</a>
+          <a th:href="@{/domain/member/list}" href="/domain/member/list">사용자</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -33,68 +33,86 @@
             <div class="card-header">
               <div class="card-title">사용자 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" href="list.html">목록</a>
+                <a class="btn" th:href="@{/domain/member/list}" href="/domain/member/list">목록</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate>
-
+              <form data-validate method="post" action="/domain/member/save" data-redirect="/domain/member/list">
                 <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-                <!-- 기본정보 -->
+                <input type="hidden" name="isNew" th:value="${isNew}" />
+
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
                       <label class="label required" for="member_id">사용자ID</label>
-                      <input id="member_id" name="member_id" class="input" required maxlength="5" placeholder="예: admin" />
+                      <input id="member_id"
+                             name="memberId"
+                             class="input"
+                             required
+                             maxlength="5"
+                             placeholder="예: admin"
+                             th:value="${member.memberId}"
+                             th:readonly="${!isNew}" />
                     </div>
                     <div class="form-row col-span-4">
                       <label class="label required" for="name">이름</label>
-                      <input id="name" name="name" class="input" required maxlength="100" />
+                      <input id="name" name="name" class="input" required maxlength="100" th:value="${member.name}" />
                     </div>
                     <div class="form-row col-span-4">
                       <label class="label" for="dept_id">부서</label>
-                      <select id="dept_id" name="dept_id">
-                        <option value="">(선택)</option>
-                        <option value="ADMIN">ADMIN</option>
-                        <option value="EQ">설비</option>
-                        <option value="AS">자산</option>
-                        <option value="EL">전기</option>
-                      </select>
+                      <input id="dept_id" name="deptId" class="input" maxlength="5" th:value="${member.deptId}" placeholder="예: EQ" />
                     </div>
                   </div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
                       <label class="label" for="email">이메일</label>
-                      <input id="email" name="email" class="input" type="email" maxlength="100" />
+                      <input id="email" name="email" class="input" type="email" maxlength="100" th:value="${member.email}" />
                     </div>
                     <div class="form-row col-span-4">
                       <label class="label" for="phone">전화번호</label>
-                      <input id="phone" name="phone" class="input" type="tel" maxlength="100" />
+                      <input id="phone" name="phone" class="input" type="tel" maxlength="100" th:value="${member.phone}" />
                     </div>
                     <div class="form-row col-span-4">
                       <label class="label" for="password">비밀번호</label>
-                      <input id="password" name="password" class="input" type="password" maxlength="100" autocomplete="new-password" />
+                      <input id="password"
+                             name="password"
+                             class="input"
+                             type="password"
+                             maxlength="100"
+                             autocomplete="new-password"
+                             placeholder="새 비밀번호 입력"
+                             th:attrappend="aria-describedby=${!isNew}? 'password-help' : null" />
                     </div>
                   </div>
                   <div class="form-row col-span-12">
                     <label class="label" for="note">비고</label>
-                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                    <textarea id="note"
+                              name="note"
+                              rows="4"
+                              maxlength="500"
+                              placeholder="기타 메모(최대 500자)"
+                              th:text="${member.note}"></textarea>
                   </div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-3">
                       <label class="label" for="delete_mark">상태</label>
-                      <select id="delete_mark" name="delete_mark">
-                        <option value="N">정상</option>
-                        <option value="Y">사용중지</option>
+                      <select id="delete_mark" name="deleteMark">
+                        <option value="N" th:selected="${member.deleteMark == null || member.deleteMark == 'N'}">정상</option>
+                        <option value="Y" th:selected="${member.deleteMark == 'Y'}">사용중지</option>
                       </select>
+                    </div>
+                    <div class="form-row col-span-9" th:if="${!isNew}" id="password-help">
+                      <p class="muted">비밀번호를 변경하지 않으려면 비워 두세요.</p>
                     </div>
                   </div>
                 </div>
 
-                <div class="actions" style="margin-top:16px">
-                  <button class="btn" type="button" onclick="history.back()">취소</button>
-                  <button class="btn primary" type="submit">저장</button>
+                <div class="row" style="margin-top:16px; gap:8px; justify-content:flex-end">
+                  <button class="btn" type="reset">초기화</button>
+                  <button class="btn primary" type="submit">
+                    <span th:text="${isNew ? '등록' : '수정'}">등록</span>
+                  </button>
                 </div>
               </form>
             </div>
@@ -102,10 +120,9 @@
         </div>
       </main>
       <footer>
-        <div class="container">© 사용자 관리</div>
+        <div class="container">© 기본정보</div>
       </footer>
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/member/list.html
+++ b/src/main/resources/templates/domain/member/list.html
@@ -10,11 +10,11 @@
     <div class="page">
       <header class="appbar">
         <div class="appbar-inner">
-          <div class="brand">사용자 관리</div>
+          <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>님 환영합니다</span>
+            <span class="badge">member</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -31,61 +31,71 @@
             <div class="card-header">
               <div class="card-title">사용자 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">내보내기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/domain/member/form}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/domain/member/list}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3">
-                    <input class="input" placeholder="사용자ID" />
+                  <div class="col-span-6">
+                    <input class="input" name="q" placeholder="사용자 ID 또는 이름" th:value="${keyword}" />
                   </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="이름/이메일" />
-                  </div>
-                  <div class="col-span-3">
-                    <select class="input">
-                      <option value="">부서(전체)</option>
-                      <option value="EQ">설비</option>
-                      <option value="AS">자산</option>
-                      <option value="EL">전기</option>
-                    </select>
-                  </div>
-                  <div class="col-span-3" style="display:flex;gap:8px;justify-content:flex-end">
-                    <button class="btn">초기화</button>
-                    <button class="btn">검색</button>
+                  <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
+                    <a class="btn" th:href="@{/domain/member/list}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
                   </div>
                 </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
                   <tr>
                     <th style="width:120px">사용자ID</th>
                     <th>이름</th>
-                    <th style="width:140px">부서</th>
-                    <th style="width:200px">이메일</th>
+                    <th style="width:120px">부서</th>
+                    <th style="width:180px">이메일</th>
+                    <th style="width:140px">전화번호</th>
                     <th style="width:100px">상태</th>
+                    <th style="width:160px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">admin</a></td>
-                    <td>Administrator</td>
-                    <td>ADMIN</td>
-                    <td>admin@example.com</td>
-                    <td><span class="badge">정상</span></td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="7" class="cell-center muted">등록된 사용자가 없습니다.</td>
+                  </tr>
+                  <tr th:each="member : ${page.content}" th:data-row-link="@{|/domain/member/edit/${member.id.memberId}|}">
+                    <td><a th:href="@{|/domain/member/edit/${member.id.memberId}|}" th:text="${member.id.memberId}">ID</a></td>
+                    <td th:text="${member.name}">-</td>
+                    <td th:text="${member.deptId}">-</td>
+                    <td th:text="${member.email}">-</td>
+                    <td th:text="${member.phone}">-</td>
+                    <td>
+                      <span class="badge" th:text="${member.deleteMark == 'Y' ? '중지' : '정상'}"
+                            th:classappend="${member.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
+                    </td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/domain/member/edit/${member.id.memberId}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/domain/member/delete/${member.id.memberId}|},data-redirect=@{/domain/member/list},data-confirm=${'사용자 ' + member.id.memberId + '을 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/domain/member/list(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/domain/member/list(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>
@@ -93,10 +103,9 @@
         </div>
       </main>
       <footer>
-        <div class="container">© 사용자 관리</div>
+        <div class="container">© 기본정보</div>
       </footer>
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/role/list.html
+++ b/src/main/resources/templates/domain/role/list.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>권한 관리 · CMMS</title>
+    <link rel="stylesheet" href="../../../static/assets/css/base.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="appbar">
+        <div class="appbar-inner">
+          <div class="brand">기본정보</div>
+          <div class="spacer"></div>
+          <div class="meta">
+            <span class="badge">role</span>
+            <span>준비중</span>
+          </div>
+        </div>
+      </header>
+      <nav class="breadcrumbs">
+        <div class="container">
+          <a href="#">기본정보</a>
+          <span class="sep">/</span>
+          <span>권한</span>
+        </div>
+      </nav>
+      <main>
+        <div class="container">
+          <section class="card">
+            <div class="card-header">
+              <div class="card-title">권한 관리</div>
+            </div>
+            <div class="card-body">
+              <p class="muted" style="margin:24px 0">권한 관리는 준비 중입니다. 향후 업데이트에서 제공될 예정입니다.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+      <footer>
+        <div class="container">© 기본정보</div>
+      </footer>
+    </div>
+    <script src="../../../static/assets/js/app.js"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/domain/site/form.html
+++ b/src/main/resources/templates/domain/site/form.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">site</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,7 +22,7 @@
         <div class="container">
           <a href="#">기본정보</a>
           <span class="sep">/</span>
-          <a href="list.html">사업장</a>
+          <a th:href="@{/domain/site/list}" href="/domain/site/list">사업장</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -33,58 +33,54 @@
             <div class="card-header">
               <div class="card-title">사업장 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" href="list.html">목록</a>
+                <a class="btn" th:href="@{/domain/site/list}" href="/domain/site/list">목록</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate>
-
+              <form data-validate method="post" action="/domain/site/save" data-redirect="/domain/site/list">
                 <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" name="isNew" th:value="${isNew}" />
+
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
                       <label class="label required" for="site_id">사업장코드</label>
-                      <input id="site_id" name="site_id" class="input" required maxlength="10" placeholder="예: S0001" />
+                      <input id="site_id"
+                             name="siteId"
+                             class="input"
+                             required
+                             maxlength="5"
+                             placeholder="예: S0001"
+                             th:value="${site.siteId}"
+                             th:readonly="${!isNew}" />
                     </div>
-                    <div class="form-row col-span-4">
+                    <div class="form-row col-span-8">
                       <label class="label required" for="site_name">사업장명</label>
-                      <input id="site_name" name="site_name" class="input" required maxlength="100" />
+                      <input id="site_name"
+                             name="name"
+                             class="input"
+                             required
+                             maxlength="100"
+                             th:value="${site.name}" />
                     </div>
-                    <div class="form-row col-span-4">
-                      <label class="label required" for="company_id">회사코드</label>
-                      <select id="company_id" name="company_id" required>
-                        <option value="">(선택)</option>
-                        <option value="C0001">C0001</option>
-                      </select>
-                    </div>
-                  </div>
-                  <div class="grid cols-12">
-                    <div class="form-row col-span-4">
-                      <label class="label" for="phone">전화번호</label>
-                      <input id="phone" name="phone" class="input" type="tel" maxlength="30" />
-                    </div>
-                    <div class="form-row col-span-4">
-                      <label class="label" for="status">상태</label>
-                      <select id="status" name="status">
-                        <option value="ACTIVE">정상</option>
-                        <option value="INACTIVE">중지</option>
-                      </select>
-                    </div>
-                  </div>
-                  <div class="form-row col-span-12">
-                    <label class="label" for="address">주소</label>
-                    <input id="address" name="address" class="input" maxlength="200" />
                   </div>
                   <div class="form-row col-span-12">
                     <label class="label" for="note">비고</label>
-                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                    <textarea id="note"
+                              name="note"
+                              rows="4"
+                              maxlength="500"
+                              placeholder="기타 메모(최대 500자)"
+                              th:text="${site.note}"></textarea>
                   </div>
                 </div>
 
                 <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
                   <button class="btn" type="reset">초기화</button>
-                  <button class="btn primary" type="submit">저장</button>
+                  <button class="btn primary" type="submit">
+                    <span th:text="${isNew ? '등록' : '수정'}">등록</span>
+                  </button>
                 </div>
               </form>
             </div>
@@ -97,5 +93,4 @@
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/site/list.html
+++ b/src/main/resources/templates/domain/site/list.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">site</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -31,56 +31,67 @@
             <div class="card-header">
               <div class="card-title">사업장 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">정보보기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/domain/site/form}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/domain/site/list}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3">
-                    <input class="input" placeholder="사업장코드" />
+                  <div class="col-span-6">
+                    <input class="input" name="q" placeholder="사업장 코드 또는 명" th:value="${keyword}" />
                   </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="사업장명" />
-                  </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="회사코드" />
-                  </div>
-                  <div class="col-span-3" style="display:flex;gap:8px;justify-content:flex-end">
-                    <button class="btn">초기화</button>
-                    <button class="btn">검색</button>
+                  <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
+                    <a class="btn" th:href="@{/domain/site/list}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
                   </div>
                 </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
                   <tr>
                     <th style="width:140px">사업장코드</th>
                     <th>사업장명</th>
-                    <th style="width:140px">회사코드</th>
-                    <th style="width:220px">주소</th>
+                    <th>비고</th>
                     <th style="width:120px">상태</th>
+                    <th style="width:160px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">S0001</a></td>
-                    <td>서울사업장</td>
-                    <td>C0001</td>
-                    <td>서울시 중구 세종대로 1</td>
-                    <td><span class="badge">정상</span></td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="5" class="cell-center muted">등록된 사업장이 없습니다.</td>
+                  </tr>
+                  <tr th:each="site : ${page.content}" th:data-row-link="@{|/domain/site/edit/${site.siteId}|}">
+                    <td><a th:href="@{|/domain/site/edit/${site.siteId}|}" th:text="${site.siteId}">SITE</a></td>
+                    <td th:text="${site.name}">-</td>
+                    <td th:text="${site.note}">-</td>
+                    <td>
+                      <span class="badge" th:text="${site.deleteMark == 'Y' ? '중지' : '정상'}"
+                            th:classappend="${site.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
+                    </td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/domain/site/edit/${site.siteId}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/domain/site/delete/${site.siteId}|},data-redirect=@{/domain/site/list},data-confirm=${'사업장 ' + site.siteId + '을 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/domain/site/list(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/domain/site/list(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>
@@ -93,5 +104,4 @@
     </div>
     <script src="../../../static/assets/js/app.js"></script>
   </body>
-  </html>
-
+</html>

--- a/src/main/resources/templates/domain/storage/form.html
+++ b/src/main/resources/templates/domain/storage/form.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">storage</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -22,7 +22,7 @@
         <div class="container">
           <a href="#">기본정보</a>
           <span class="sep">/</span>
-          <a href="list.html">창고</a>
+          <a th:href="@{/domain/storage/list}" href="/domain/storage/list">창고</a>
           <span class="sep">/</span>
           <span>등록/수정</span>
         </div>
@@ -33,32 +33,54 @@
             <div class="card-header">
               <div class="card-title">창고 등록/수정</div>
               <div class="toolbar">
-                <a class="btn" href="list.html">목록</a>
+                <a class="btn" th:href="@{/domain/storage/list}" href="/domain/storage/list">목록</a>
               </div>
             </div>
             <div class="card-body">
-              <form data-validate>
+              <form data-validate method="post" action="/domain/storage/save" data-redirect="/domain/storage/list">
+                <input type="hidden" name="_csrf" value="" data-csrf-field="true" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" name="isNew" th:value="${isNew}" />
+
                 <div class="section">
                   <div class="section-title">기본정보</div>
                   <div class="grid cols-12">
                     <div class="form-row col-span-4">
-                      <label class="label required" for="storage_id">창고 코드</label>
-                      <input id="storage_id" name="storage_id" class="input" required maxlength="5" placeholder="예: ST001" />
+                      <label class="label required" for="storage_id">창고코드</label>
+                      <input id="storage_id"
+                             name="storageId"
+                             class="input"
+                             required
+                             maxlength="5"
+                             placeholder="예: ST001"
+                             th:value="${storage.storageId}"
+                             th:readonly="${!isNew}" />
                     </div>
                     <div class="form-row col-span-8">
-                      <label class="label required" for="name">창고 명</label>
-                      <input id="name" name="name" class="input" required maxlength="100" />
+                      <label class="label required" for="storage_name">창고명</label>
+                      <input id="storage_name"
+                             name="name"
+                             class="input"
+                             required
+                             maxlength="100"
+                             th:value="${storage.name}" />
                     </div>
                   </div>
                   <div class="form-row col-span-12">
                     <label class="label" for="note">비고</label>
-                    <textarea id="note" name="note" rows="4" maxlength="500" placeholder="기타 메모(최대 500자)"></textarea>
+                    <textarea id="note"
+                              name="note"
+                              rows="4"
+                              maxlength="500"
+                              placeholder="기타 메모(최대 500자)"
+                              th:text="${storage.note}"></textarea>
                   </div>
                 </div>
 
                 <div class="row" style="margin-top:12px; gap:8px; justify-content:flex-end">
                   <button class="btn" type="reset">초기화</button>
-                  <button class="btn primary" type="submit">저장</button>
+                  <button class="btn primary" type="submit">
+                    <span th:text="${isNew ? '등록' : '수정'}">등록</span>
+                  </button>
                 </div>
               </form>
             </div>
@@ -72,4 +94,3 @@
     <script src="../../../static/assets/js/app.js"></script>
   </body>
 </html>
-

--- a/src/main/resources/templates/domain/storage/list.html
+++ b/src/main/resources/templates/domain/storage/list.html
@@ -13,8 +13,8 @@
           <div class="brand">기본정보</div>
           <div class="spacer"></div>
           <div class="meta">
-            <span class="badge">memberId</span>
-            <span>운영중</span>
+            <span class="badge">storage</span>
+            <span>관리</span>
           </div>
         </div>
       </header>
@@ -31,49 +31,67 @@
             <div class="card-header">
               <div class="card-title">창고 목록</div>
               <div class="toolbar">
-                <a class="btn" href="#">정보보기</a>
-                <a class="btn primary" href="form.html">새로 만들기</a>
+                <a class="btn primary" th:href="@{/domain/storage/form}">새로 만들기</a>
               </div>
             </div>
             <div class="card-body">
-              <div class="section">
+              <form class="section" method="get" th:action="@{/domain/storage/list}">
                 <div class="section-title">필터</div>
                 <div class="grid cols-12">
-                  <div class="col-span-3">
-                    <input class="input" placeholder="창고 코드" />
-                  </div>
-                  <div class="col-span-3">
-                    <input class="input" placeholder="창고 명" />
+                  <div class="col-span-6">
+                    <input class="input" name="q" placeholder="창고 코드 또는 명" th:value="${keyword}" />
                   </div>
                   <div class="col-span-6" style="display:flex;gap:8px;justify-content:flex-end">
-                    <button class="btn">초기화</button>
-                    <button class="btn">검색</button>
+                    <a class="btn" th:href="@{/domain/storage/list}">초기화</a>
+                    <button class="btn" type="submit">검색</button>
                   </div>
                 </div>
-              </div>
+              </form>
 
               <table class="table">
                 <thead>
                   <tr>
-                    <th style="width:140px">창고 코드</th>
-                    <th>창고 명</th>
-                    <th style="width:200px">비고</th>
+                    <th style="width:140px">창고코드</th>
+                    <th>창고명</th>
+                    <th>비고</th>
+                    <th style="width:120px">상태</th>
+                    <th style="width:160px">액션</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr data-row-link="form.html">
-                    <td><a href="form.html">ST001</a></td>
-                    <td>중앙 창고</td>
-                    <td>예시 데이터</td>
+                  <tr th:if="${page.empty}">
+                    <td colspan="5" class="cell-center muted">등록된 창고가 없습니다.</td>
+                  </tr>
+                  <tr th:each="storage : ${page.content}" th:data-row-link="@{|/domain/storage/edit/${storage.storageId}|}">
+                    <td><a th:href="@{|/domain/storage/edit/${storage.storageId}|}" th:text="${storage.storageId}">ST001</a></td>
+                    <td th:text="${storage.name}">-</td>
+                    <td th:text="${storage.note}">-</td>
+                    <td>
+                      <span class="badge" th:text="${storage.deleteMark == 'Y' ? '중지' : '정상'}"
+                            th:classappend="${storage.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
+                    </td>
+                    <td class="actions">
+                      <a class="btn sm" th:href="@{|/domain/storage/edit/${storage.storageId}|}">수정</a>
+                      <button class="btn sm danger"
+                              type="button"
+                              th:attr="data-delete-url=@{|/domain/storage/delete/${storage.storageId}|},data-redirect=@{/domain/storage/list},data-confirm=${'창고 ' + storage.storageId + '를 삭제할까요?'}">
+                        삭제
+                      </button>
+                    </td>
                   </tr>
                 </tbody>
               </table>
 
               <div class="row" style="margin-top:12px">
                 <div class="spacer"></div>
-                <div class="pagination">
-                  <button class="btn sm" disabled>이전</button>
-                  <button class="btn sm">다음</button>
+                <div class="pagination" th:if="${page.totalPages > 0}">
+                  <a class="btn sm"
+                     th:classappend="${page.first}? ' disabled' : ''"
+                     th:href="@{/domain/storage/list(page=${page.number > 0 ? page.number - 1 : 0}, size=${page.size}, q=${keyword})}">이전</a>
+                  <span class="page-info" th:text="|${page.number + 1} / ${page.totalPages == 0 ? 1 : page.totalPages}|">1 / 1</span>
+                  <a class="btn sm"
+                     th:classappend="${page.last}? ' disabled' : ''"
+                     th:href="@{/domain/storage/list(page=${page.last ? page.number : page.number + 1}, size=${page.size}, q=${keyword})}">다음</a>
                 </div>
               </div>
             </div>

--- a/src/main/resources/templates/layout/defaultLayout.html
+++ b/src/main/resources/templates/layout/defaultLayout.html
@@ -130,13 +130,21 @@
           <div class="menu-group" data-group>
             <button type="button" class="menu-title" aria-expanded="false">기본정보</button>
             <div class="menu-items">
-              <a class="menu-item" href="/domain/company/list">회사</a>
-              <a class="menu-item" href="/domain/site/list">사업장(사이트)</a>
-              <a class="menu-item" href="/domain/dept/list">부서</a>
-              <a class="menu-item" href="/domain/func/list">기능위치</a>
-              <a class="menu-item" href="/domain/storage/list">창고(스토리지)</a>
-              <a class="menu-item" href="/domain/member/list">사용자</a>
-              <a class="menu-item" href="/domain/role/list">권한</a>
+              <a class="menu-item" href="@{/domain/company/list}">회사</a>
+              <a class="menu-item" href="@{/domain/site/list}">사업장(사이트)</a>
+              <a class="menu-item" href="@{/domain/dept/list}">부서</a>
+              <a class="menu-item" href="@{/domain/func/list}">기능위치</a>
+              <a class="menu-item" href="@{/domain/storage/list}">창고(스토리지)</a>
+              <a class="menu-item" href="@{/domain/member/list}">사용자</a>
+              <a class="menu-item" href="@{/domain/role/list}">권한</a>
+            </div>
+          </div>
+
+          <div class="menu-group" data-group>
+            <button type="button" class="menu-title" aria-expanded="false">공통코드</button>
+            <div class="menu-items">
+              <a class="menu-item" href="@{/code/types}">코드 타입</a>
+              <a class="menu-item" href="@{/code/items}">코드 항목</a>
             </div>
           </div>
         </nav>


### PR DESCRIPTION
## Summary
- add Thymeleaf-based view controllers for domain modules and code management so pages render inside the default layout slot
- align domain and code templates with service DTO fields, add dynamic lists/forms, and surface placeholder view for roles
- extend member service/view handling for create/update/delete and wire new navigation links in the sidebar

## Testing
- `./gradlew test` *(fails: Maven Central responded with HTTP 403 while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d07ac7651c83239c76468a3bfcb294