### PR TITLE
feat: unify domain form routing

### DIFF
--- a/src/main/java/com/cmms11/web/CompanyController.java
+++ b/src/main/java/com/cmms11/web/CompanyController.java
@@ -45,8 +45,12 @@ public class CompanyController {
         return "domain/company/list";
     }
 
-    @GetMapping("/domain/company/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/company/form", "/domain/company/form/{companyId}"})
+    public String form(@PathVariable(value = "companyId", required = false) String companyId, Model model) {
+        return companyId == null ? newForm(model) : editForm(companyId, model);
+    }
+
+    private String newForm(Model model) {
         model.addAttribute("company", new CompanyResponse(
             null, // companyId
             null, // name
@@ -64,8 +68,7 @@ public class CompanyController {
         return "domain/company/form";
     }
 
-    @GetMapping("/domain/company/edit/{companyId}")
-    public String editForm(@PathVariable String companyId, Model model) {
+    private String editForm(String companyId, Model model) {
         CompanyResponse company = service.get(companyId);
         model.addAttribute("company", company);
         model.addAttribute("isNew", false);

--- a/src/main/java/com/cmms11/web/DeptController.java
+++ b/src/main/java/com/cmms11/web/DeptController.java
@@ -44,8 +44,12 @@ public class DeptController {
         return "domain/dept/list";
     }
 
-    @GetMapping("/domain/dept/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/dept/form", "/domain/dept/form/{deptId}"})
+    public String form(@PathVariable(value = "deptId", required = false) String deptId, Model model) {
+        return deptId == null ? newForm(model) : editForm(deptId, model);
+    }
+
+    private String newForm(Model model) {
         model.addAttribute("dept", new DeptResponse(
             null,
             null,
@@ -60,8 +64,7 @@ public class DeptController {
         return "domain/dept/form";
     }
 
-    @GetMapping("/domain/dept/edit/{deptId}")
-    public String editForm(@PathVariable String deptId, Model model) {
+    private String editForm(String deptId, Model model) {
         DeptResponse dept = service.get(deptId);
         model.addAttribute("dept", dept);
         model.addAttribute("isNew", false);

--- a/src/main/java/com/cmms11/web/FuncController.java
+++ b/src/main/java/com/cmms11/web/FuncController.java
@@ -44,8 +44,12 @@ public class FuncController {
         return "domain/func/list";
     }
 
-    @GetMapping("/domain/func/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/func/form", "/domain/func/form/{funcId}"})
+    public String form(@PathVariable(value = "funcId", required = false) String funcId, Model model) {
+        return funcId == null ? newForm(model) : editForm(funcId, model);
+    }
+
+    private String newForm(Model model) {
         model.addAttribute("func", new FuncResponse(
             null,
             null,
@@ -60,8 +64,7 @@ public class FuncController {
         return "domain/func/form";
     }
 
-    @GetMapping("/domain/func/edit/{funcId}")
-    public String editForm(@PathVariable String funcId, Model model) {
+    private String editForm(String funcId, Model model) {
         FuncResponse func = service.get(funcId);
         model.addAttribute("func", func);
         model.addAttribute("isNew", false);

--- a/src/main/java/com/cmms11/web/MemberController.java
+++ b/src/main/java/com/cmms11/web/MemberController.java
@@ -36,8 +36,12 @@ public class MemberController {
         return "domain/member/list";
     }
 
-    @GetMapping("/domain/member/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/member/form", "/domain/member/form/{memberId}"})
+    public String form(@PathVariable(value = "memberId", required = false) String memberId, Model model) {
+        return memberId == null ? newForm(model) : editForm(memberId, model);
+    }
+
+    private String newForm(Model model) {
         MemberForm form = new MemberForm();
         form.setDeleteMark("N");
         model.addAttribute("member", form);
@@ -45,8 +49,7 @@ public class MemberController {
         return "domain/member/form";
     }
 
-    @GetMapping("/domain/member/edit/{memberId}")
-    public String editForm(@PathVariable String memberId, Model model) {
+    private String editForm(String memberId, Model model) {
         Member member = service.get(memberId);
         MemberForm form = toForm(member);
         model.addAttribute("member", form);

--- a/src/main/java/com/cmms11/web/MemberViewController.java
+++ b/src/main/java/com/cmms11/web/MemberViewController.java
@@ -73,7 +73,7 @@ public class MemberViewController {
 
     @PostMapping("/delete/{memberId}")
     public String delete(@PathVariable String memberId) {
-        service.delete(memberId);
+        service.delete(memberId, null);
         return "redirect:/domain/member/list";
     }
 

--- a/src/main/java/com/cmms11/web/RoleController.java
+++ b/src/main/java/com/cmms11/web/RoleController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;

--- a/src/main/java/com/cmms11/web/SiteController.java
+++ b/src/main/java/com/cmms11/web/SiteController.java
@@ -44,8 +44,12 @@ public class SiteController {
         return "domain/site/list";
     }
 
-    @GetMapping("/domain/site/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/site/form", "/domain/site/form/{siteId}"})
+    public String form(@PathVariable(value = "siteId", required = false) String siteId, Model model) {
+        return siteId == null ? newForm(model) : editForm(siteId, model);
+    }
+
+    private String newForm(Model model) {
         model.addAttribute("site", new SiteResponse(
             null,
             null,
@@ -60,8 +64,7 @@ public class SiteController {
         return "domain/site/form";
     }
 
-    @GetMapping("/domain/site/edit/{siteId}")
-    public String editForm(@PathVariable String siteId, Model model) {
+    private String editForm(String siteId, Model model) {
         SiteResponse site = service.get(siteId);
         model.addAttribute("site", site);
         model.addAttribute("isNew", false);

--- a/src/main/java/com/cmms11/web/StorageController.java
+++ b/src/main/java/com/cmms11/web/StorageController.java
@@ -44,8 +44,12 @@ public class StorageController {
         return "domain/storage/list";
     }
 
-    @GetMapping("/domain/storage/form")
-    public String newForm(Model model) {
+    @GetMapping({"/domain/storage/form", "/domain/storage/form/{storageId}"})
+    public String form(@PathVariable(value = "storageId", required = false) String storageId, Model model) {
+        return storageId == null ? newForm(model) : editForm(storageId, model);
+    }
+
+    private String newForm(Model model) {
         model.addAttribute("storage", new StorageResponse(
             null,
             null,
@@ -60,8 +64,7 @@ public class StorageController {
         return "domain/storage/form";
     }
 
-    @GetMapping("/domain/storage/edit/{storageId}")
-    public String editForm(@PathVariable String storageId, Model model) {
+    private String editForm(String storageId, Model model) {
         StorageResponse storage = service.get(storageId);
         model.addAttribute("storage", storage);
         model.addAttribute("isNew", false);

--- a/src/main/resources/templates/domain/company/list.html
+++ b/src/main/resources/templates/domain/company/list.html
@@ -68,7 +68,7 @@
                 </thead>
                 <tbody>
                   <tr th:each="company : ${page.content}">
-                    <td><a th:href="@{/domain/company/edit/{id}(id=${company.companyId})}" th:text="${company.companyId}">-</a></td>
+                    <td><a th:href="@{/domain/company/form/{id}(id=${company.companyId})}" th:text="${company.companyId}">-</a></td>
                     <td th:text="${company.name}">-</td>
                     <td th:text="${company.bizNo}">-</td>
                     <td th:text="${company.note}">-</td>
@@ -76,7 +76,7 @@
                       <span class="badge" th:text="${company.deleteMark == 'N' ? '정상' : '중지'}" th:classappend="${company.deleteMark == 'N' ? 'badge' : 'badge danger'}">-</span>
                     </td>
                     <td class="actions">
-                      <a class="btn btn-sm" th:href="@{~/domain/company/edit/{id}(id=${company.companyId})}">수정</a>
+                      <a class="btn btn-sm" th:href="@{~/domain/company/form/{id}(id=${company.companyId})}">수정</a>
                       <button class="btn btn-sm danger" th:data-company-id="${company.companyId}" onclick="deleteCompany(this.dataset.companyId)">삭제</button>
                     </td>
                   </tr>

--- a/src/main/resources/templates/domain/dept/list.html
+++ b/src/main/resources/templates/domain/dept/list.html
@@ -62,8 +62,8 @@
                   <tr th:if="${page.empty}">
                     <td colspan="5" class="cell-center muted">등록된 부서가 없습니다.</td>
                   </tr>
-                  <tr th:each="dept : ${page.content}" th:data-row-link="@{|/domain/dept/edit/${dept.deptId}|}">
-                    <td><a th:href="@{|/domain/dept/edit/${dept.deptId}|}" th:text="${dept.deptId}">DEPT</a></td>
+                  <tr th:each="dept : ${page.content}" th:data-row-link="@{|/domain/dept/form/${dept.deptId}|}">
+                    <td><a th:href="@{|/domain/dept/form/${dept.deptId}|}" th:text="${dept.deptId}">DEPT</a></td>
                     <td th:text="${dept.name}">-</td>
                     <td th:text="${dept.note}">-</td>
                     <td>
@@ -71,7 +71,7 @@
                             th:classappend="${dept.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
                     </td>
                     <td class="actions">
-                      <a class="btn sm" th:href="@{|/domain/dept/edit/${dept.deptId}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/domain/dept/form/${dept.deptId}|}">수정</a>
                       <button class="btn sm danger"
                               type="button"
                               th:attr="data-delete-url=@{|/domain/dept/delete/${dept.deptId}|},data-redirect=@{/domain/dept/list},data-confirm=${'부서 ' + dept.deptId + '을 삭제할까요?'}">

--- a/src/main/resources/templates/domain/func/list.html
+++ b/src/main/resources/templates/domain/func/list.html
@@ -62,8 +62,8 @@
                   <tr th:if="${page.empty}">
                     <td colspan="5" class="cell-center muted">등록된 기능위치가 없습니다.</td>
                   </tr>
-                  <tr th:each="func : ${page.content}" th:data-row-link="@{|/domain/func/edit/${func.funcId}|}">
-                    <td><a th:href="@{|/domain/func/edit/${func.funcId}|}" th:text="${func.funcId}">FUNC</a></td>
+                  <tr th:each="func : ${page.content}" th:data-row-link="@{|/domain/func/form/${func.funcId}|}">
+                    <td><a th:href="@{|/domain/func/form/${func.funcId}|}" th:text="${func.funcId}">FUNC</a></td>
                     <td th:text="${func.name}">-</td>
                     <td th:text="${func.note}">-</td>
                     <td>
@@ -71,7 +71,7 @@
                             th:classappend="${func.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
                     </td>
                     <td class="actions">
-                      <a class="btn sm" th:href="@{|/domain/func/edit/${func.funcId}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/domain/func/form/${func.funcId}|}">수정</a>
                       <button class="btn sm danger"
                               type="button"
                               th:attr="data-delete-url=@{|/domain/func/delete/${func.funcId}|},data-redirect=@{/domain/func/list},data-confirm=${'기능위치 ' + func.funcId + '를 삭제할까요?'}">

--- a/src/main/resources/templates/domain/member/list.html
+++ b/src/main/resources/templates/domain/member/list.html
@@ -64,8 +64,8 @@
                   <tr th:if="${page.empty}">
                     <td colspan="7" class="cell-center muted">등록된 사용자가 없습니다.</td>
                   </tr>
-                  <tr th:each="member : ${page.content}" th:data-row-link="@{|/domain/member/edit/${member.id.memberId}|}">
-                    <td><a th:href="@{|/domain/member/edit/${member.id.memberId}|}" th:text="${member.id.memberId}">ID</a></td>
+                  <tr th:each="member : ${page.content}" th:data-row-link="@{|/domain/member/form/${member.id.memberId}|}">
+                    <td><a th:href="@{|/domain/member/form/${member.id.memberId}|}" th:text="${member.id.memberId}">ID</a></td>
                     <td th:text="${member.name}">-</td>
                     <td th:text="${member.deptId}">-</td>
                     <td th:text="${member.email}">-</td>
@@ -75,7 +75,7 @@
                             th:classappend="${member.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
                     </td>
                     <td class="actions">
-                      <a class="btn sm" th:href="@{|/domain/member/edit/${member.id.memberId}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/domain/member/form/${member.id.memberId}|}">수정</a>
                       <button class="btn sm danger"
                               type="button"
                               th:attr="data-delete-url=@{|/domain/member/delete/${member.id.memberId}|},data-redirect=@{/domain/member/list},data-confirm=${'사용자 ' + member.id.memberId + '을 삭제할까요?'}">

--- a/src/main/resources/templates/domain/site/list.html
+++ b/src/main/resources/templates/domain/site/list.html
@@ -62,8 +62,8 @@
                   <tr th:if="${page.empty}">
                     <td colspan="5" class="cell-center muted">등록된 사업장이 없습니다.</td>
                   </tr>
-                  <tr th:each="site : ${page.content}" th:data-row-link="@{|/domain/site/edit/${site.siteId}|}">
-                    <td><a th:href="@{|/domain/site/edit/${site.siteId}|}" th:text="${site.siteId}">SITE</a></td>
+                  <tr th:each="site : ${page.content}" th:data-row-link="@{|/domain/site/form/${site.siteId}|}">
+                    <td><a th:href="@{|/domain/site/form/${site.siteId}|}" th:text="${site.siteId}">SITE</a></td>
                     <td th:text="${site.name}">-</td>
                     <td th:text="${site.note}">-</td>
                     <td>
@@ -71,7 +71,7 @@
                             th:classappend="${site.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
                     </td>
                     <td class="actions">
-                      <a class="btn sm" th:href="@{|/domain/site/edit/${site.siteId}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/domain/site/form/${site.siteId}|}">수정</a>
                       <button class="btn sm danger"
                               type="button"
                               th:attr="data-delete-url=@{|/domain/site/delete/${site.siteId}|},data-redirect=@{/domain/site/list},data-confirm=${'사업장 ' + site.siteId + '을 삭제할까요?'}">

--- a/src/main/resources/templates/domain/storage/list.html
+++ b/src/main/resources/templates/domain/storage/list.html
@@ -62,8 +62,8 @@
                   <tr th:if="${page.empty}">
                     <td colspan="5" class="cell-center muted">등록된 창고가 없습니다.</td>
                   </tr>
-                  <tr th:each="storage : ${page.content}" th:data-row-link="@{|/domain/storage/edit/${storage.storageId}|}">
-                    <td><a th:href="@{|/domain/storage/edit/${storage.storageId}|}" th:text="${storage.storageId}">ST001</a></td>
+                  <tr th:each="storage : ${page.content}" th:data-row-link="@{|/domain/storage/form/${storage.storageId}|}">
+                    <td><a th:href="@{|/domain/storage/form/${storage.storageId}|}" th:text="${storage.storageId}">ST001</a></td>
                     <td th:text="${storage.name}">-</td>
                     <td th:text="${storage.note}">-</td>
                     <td>
@@ -71,7 +71,7 @@
                             th:classappend="${storage.deleteMark == 'Y'} ? ' danger' : ''">정상</span>
                     </td>
                     <td class="actions">
-                      <a class="btn sm" th:href="@{|/domain/storage/edit/${storage.storageId}|}">수정</a>
+                      <a class="btn sm" th:href="@{|/domain/storage/form/${storage.storageId}|}">수정</a>
                       <button class="btn sm danger"
                               type="button"
                               th:attr="data-delete-url=@{|/domain/storage/delete/${storage.storageId}|},data-redirect=@{/domain/storage/list},data-confirm=${'창고 ' + storage.storageId + '를 삭제할까요?'}">

--- a/src/test/java/com/cmms11/web/CompanyControllerTest.java
+++ b/src/test/java/com/cmms11/web/CompanyControllerTest.java
@@ -87,7 +87,7 @@ class CompanyControllerTest {
         CompanyResponse response = new CompanyResponse("C0001", "샘플회사", "123-45-67890", "test@company.com", "02-1234-5678", "메모", "N", now, "tester", now, "tester");
         when(companyService.get("C0001")).thenReturn(response);
 
-        mockMvc.perform(get("/domain/company/edit/{companyId}", "C0001"))
+        mockMvc.perform(get("/domain/company/form/{companyId}", "C0001"))
             .andExpect(status().isOk())
             .andExpect(view().name("domain/company/form"))
             .andExpect(model().attribute("company", response))


### PR DESCRIPTION
## Summary
- replace the separate /form and /edit routes in the domain controllers with a single optional-id form handler that delegates to the existing new/edit helpers
- update the Thymeleaf list views and MVC test to link to /domain/{mod}/form/{id}, keeping isNew binding intact across SPA navigation
- add the missing PutMapping import and align the member view delete call with the service signature so the module compiles

## Testing
- ./gradlew test *(fails: Maven Central returned 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e5fdba348323a1dc120fc0b2e070