### PR TITLE
fix: align code form model attributes

### DIFF
--- a/src/main/java/com/cmms11/web/CodeController.java
+++ b/src/main/java/com/cmms11/web/CodeController.java
@@ -54,18 +54,9 @@ public class CodeController {
 
     @GetMapping("/code/form")
     public String newForm(Model model) {
-        model.addAttribute("codeType", new CodeTypeResponse(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ));
-        model.addAttribute("items", List.of());
-        model.addAttribute("form", new CodeForm());
+        CodeForm form = new CodeForm();
+        model.addAttribute("type", form);
+        model.addAttribute("items", form.getItems());
         model.addAttribute("isNew", true);
         return "code/form";
     }
@@ -79,9 +70,8 @@ public class CodeController {
         form.setName(type.name());
         form.setNote(type.note());
         form.setItems(items.stream().map(CodeItemForm::from).collect(Collectors.toCollection(ArrayList::new)));
-        model.addAttribute("codeType", type);
-        model.addAttribute("items", items);
-        model.addAttribute("form", form);
+        model.addAttribute("type", form);
+        model.addAttribute("items", form.getItems());
         model.addAttribute("isNew", false);
         return "code/form";
     }


### PR DESCRIPTION
## Summary
- expose the `type` and `items` attributes from `CodeController` using the existing `CodeForm` so the Thymeleaf form bindings resolve correctly
- drop the unused `codeType` and `form` attributes to keep the model focused on the fields the template expects

## Testing
- ./gradlew test *(fails: compilation stops in RoleController because PutMapping is not imported)*
- ./gradlew bootRun *(fails: compilation stops in RoleController because PutMapping is not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e60204d88323868901a956ffb2d1